### PR TITLE
Add some structure around adding customizations to core blocks.

### DIFF
--- a/themes/10up-theme/functions.php
+++ b/themes/10up-theme/functions.php
@@ -9,6 +9,8 @@
 define( 'TENUP_THEME_VERSION', '0.1.0' );
 define( 'TENUP_THEME_TEMPLATE_URL', get_template_directory_uri() );
 define( 'TENUP_THEME_PATH', get_template_directory() . '/' );
+define( 'TENUP_THEME_DIST_PATH', TENUP_THEME_PATH . 'dist/' );
+define( 'TENUP_THEME_DIST_URL', TENUP_THEME_TEMPLATE_URL . '/dist/' );
 define( 'TENUP_THEME_INC', TENUP_THEME_PATH . 'includes/' );
 define( 'TENUP_THEME_BLOCK_DIR', TENUP_THEME_INC . 'blocks/' );
 

--- a/themes/10up-theme/includes/block-filters/index.js
+++ b/themes/10up-theme/includes/block-filters/index.js
@@ -1,0 +1,6 @@
+/**
+ * Entry point for block filters.
+ */
+
+// Each block that needs filters to be applied, should have it's own file.
+// import './button'

--- a/themes/10up-theme/includes/block-styles/index.js
+++ b/themes/10up-theme/includes/block-styles/index.js
@@ -1,0 +1,6 @@
+/**
+ * Entry point for block styles.
+ */
+
+// Each block that needs custom styles should have it's own file.
+// import './button'

--- a/themes/10up-theme/includes/block-variations/index.js
+++ b/themes/10up-theme/includes/block-variations/index.js
@@ -1,0 +1,6 @@
+/**
+ * Entry point for block variations.
+ */
+
+// Each block that needs variations should have it's own file.
+// import './button'

--- a/themes/10up-theme/includes/blocks.php
+++ b/themes/10up-theme/includes/blocks.php
@@ -26,6 +26,8 @@ function setup() {
 
 	add_action( 'init', $n( 'register_theme_blocks' ) );
 
+	add_action( 'init', $n( 'block_patterns_and_categories') );
+
 	/*
 	If you are using the block library, remove the blocks you don't need.
 
@@ -110,4 +112,41 @@ function blocks_categories( $categories, $post ) {
 			),
 		)
 	);
+}
+
+/**
+ * Manage block patterns and block pattern categories
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-patterns/
+ *
+ * @return void
+ */
+function block_patterns_and_categories() {
+
+	/*
+	## Examples
+
+	// Register block pattern
+	register_block_pattern(
+		'tenup/block-pattern',
+		array(
+        	'title'       => __( 'Two buttons', 'tenup' ),
+        	'description' => _x( 'Two horizontal buttons, the left button is filled in, and the right button is outlined.', 'Block pattern description', 'wpdocs-my-plugin' ),
+        	'content'     => "<!-- wp:buttons {\"align\":\"center\"} -->\n<div class=\"wp-block-buttons aligncenter\"><!-- wp:button {\"backgroundColor\":\"very-dark-gray\",\"borderRadius\":0} -->\n<div class=\"wp-block-button\"><a class=\"wp-block-button__link has-background has-very-dark-gray-background-color no-border-radius\">" . esc_html__( 'Button One', 'wpdocs-my-plugin' ) . "</a></div>\n<!-- /wp:button -->\n\n<!-- wp:button {\"textColor\":\"very-dark-gray\",\"borderRadius\":0,\"className\":\"is-style-outline\"} -->\n<div class=\"wp-block-button is-style-outline\"><a class=\"wp-block-button__link has-text-color has-very-dark-gray-color no-border-radius\">" . esc_html__( 'Button Two', 'wpdocs-my-plugin' ) . "</a></div>\n<!-- /wp:button --></div>\n<!-- /wp:buttons -->",
+    	)
+	);
+
+	// Unregister a block pattern
+	unregister_block_pattern( 'tenup/block-pattern' );
+
+	// Register a block pattern category
+	register_block_pattern_category(
+		'client-name',
+			array( 'label' => __( 'Client Name', 'tenup' ) )
+	);
+
+	// Unregister a block pattern category
+	unregister_block_pattern('client-name')
+
+	*/
 }

--- a/themes/10up-theme/includes/core-block-overrides.js
+++ b/themes/10up-theme/includes/core-block-overrides.js
@@ -1,0 +1,7 @@
+/**
+ * Entry point for all core block overrides
+ */
+
+// import './block-filters';
+// import './block-styles';
+// import './block-variations';

--- a/themes/10up-theme/includes/core.php
+++ b/themes/10up-theme/includes/core.php
@@ -24,6 +24,7 @@ function setup() {
 	add_action( 'wp_enqueue_scripts', $n( 'scripts' ) );
 	add_action( 'admin_enqueue_scripts', $n( 'admin_styles' ) );
 	add_action( 'admin_enqueue_scripts', $n( 'admin_scripts' ) );
+	add_action( 'enqueue_block_editor_assets', $n( 'core_block_overrides' ) );
 	add_action( 'wp_enqueue_scripts', $n( 'styles' ) );
 	add_action( 'wp_head', $n( 'js_detection' ), 0 );
 	add_action( 'wp_head', $n( 'add_manifest' ), 10 );
@@ -126,6 +127,25 @@ function admin_scripts() {
 		true
 	);
 	*/
+}
+
+/**
+ * Enqueue core block filters, styles and variations.
+ *
+ * @return void
+ */
+function core_block_overrides() {
+	$overrides = TENUP_THEME_DIST_PATH . 'js/core-block-overrides.asset.php';
+	if ( file_exists( $overrides ) ) {
+		$dep = require_once $overrides;
+		wp_enqueue_script(
+			'tenup-block-library-editor-script',
+			TENUP_THEME_DIST_URL . 'js/core-block-overrides.js',
+			$dep['dependencies'],
+			$dep['version'],
+			true
+		);
+	}
 }
 
 /**

--- a/themes/10up-theme/includes/core.php
+++ b/themes/10up-theme/includes/core.php
@@ -139,7 +139,7 @@ function core_block_overrides() {
 	if ( file_exists( $overrides ) ) {
 		$dep = require_once $overrides;
 		wp_enqueue_script(
-			'tenup-block-library-block-overrides-script',
+			'core-block-overrides',
 			TENUP_THEME_DIST_URL . 'js/core-block-overrides.js',
 			$dep['dependencies'],
 			$dep['version'],

--- a/themes/10up-theme/includes/core.php
+++ b/themes/10up-theme/includes/core.php
@@ -139,7 +139,7 @@ function core_block_overrides() {
 	if ( file_exists( $overrides ) ) {
 		$dep = require_once $overrides;
 		wp_enqueue_script(
-			'tenup-block-library-editor-script',
+			'tenup-block-library-block-overrides-script',
 			TENUP_THEME_DIST_URL . 'js/core-block-overrides.js',
 			$dep['dependencies'],
 			$dep['version'],

--- a/themes/10up-theme/package.json
+++ b/themes/10up-theme/package.json
@@ -33,6 +33,7 @@
       "shared-style": "./assets/css/shared/shared-style.css",
       "style": "./assets/css/frontend/style.css",
       "styleguide-style": "./assets/css/styleguide/styleguide.css",
+      "core-block-overrides": "./includes/core-block-overrides.js",
       "example-block": "./includes/blocks/example-block/index.js"
     }
   }


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR introduces some structure around adding block filters, styles, patterns and variations for core blocks. 
Addresses #18 

- Adds a new entrypoint for `core-block-overrides` and corresponding file.
- Adds dedicated directories for filters , styles, and variations
- Adds new hook callback for Block Patterns

### Benefits
Adding these customizations is done on most, if not all 10up projects. Having a defined structure for will provide guidance as well as reduce developer ramp-up on projects as they know what to expect.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
