### PR TITLE
Replace rem with em

### DIFF
--- a/themes/10up-theme/assets/css/frontend/base/wordpress.css
+++ b/themes/10up-theme/assets/css/frontend/base/wordpress.css
@@ -2,13 +2,13 @@
 
 .alignleft {
 	float: left;
-	margin-right: 1rem;
+	margin-right: 1em;
 	text-align: left;
 }
 
 .alignright {
 	float: right;
-	margin-left: 1rem;
+	margin-left: 1em;
 	text-align: right;
 }
 


### PR DESCRIPTION
Using rem-based sizing does not / may not play well in the context of the block editor, the base font size in the admin might be different making it harder to style blocks in the editor identically to the front end.