### PR TITLE
Disable support options as a default starting point.

### DIFF
--- a/themes/10up-theme/includes/blocks/example-block/block.json
+++ b/themes/10up-theme/includes/blocks/example-block/block.json
@@ -15,5 +15,26 @@
       "customTitle": "Example Block"
     }
   },
+  "supports": {
+		"align": false,
+		"alignWide": false,
+		"anchor": false,
+		"color":{
+			"gradients": false,
+			"background": false,
+			"text": false
+		},
+		"customClassName": false,
+		"defaultStylePicker": false,
+		"fontSize": false,
+		"html": false,
+		"inserter": true,
+		"lineHeight": true,
+		"multiple": true,
+		"reusable": false,
+		"spacing": {
+			"padding": false
+		}
+	},
 	"editorScript": "file:../../../dist/blocks/example-block/editor.js"
 }


### PR DESCRIPTION
### Description of the Change

This PR disables all `supports` non-standard options as a starting point for a new block. Also implicitly sets items that are true by default. 

### Benefits
By ensuring that using a feature requires a step, the block being created will be more purpose-built and consistent. By displaying all options ( even ones that are set by default ) will also show what is possible for the block.

### Possible Drawbacks
Items such as custom class names that are usually enabled by default will require a step to enable.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
