### PR TITLE
Remove DropCap setting from the Core Paragraph Block by default

### DIFF
--- a/themes/10up-theme/includes/blocks.php
+++ b/themes/10up-theme/includes/blocks.php
@@ -28,6 +28,8 @@ function setup() {
 
 	add_action( 'init', $n( 'block_patterns_and_categories') );
 
+	add_action( 'init', $n( 'disable_drop_cap_setting' ) );
+
 	/*
 	If you are using the block library, remove the blocks you don't need.
 
@@ -149,4 +151,48 @@ function block_patterns_and_categories() {
 	unregister_block_pattern('client-name')
 
 	*/
+}
+
+/**
+ * Disable the block editor setting to add a drop cap to a paragraph
+ *
+ * The DropCap setting can get disabled via the theme.json file. Since this mechanism currently is
+ * only available in the Gutenberg Plugin there is a way to filter these setting in core. Since the
+ * theme.json format is still experimental however the format for disabling the dropCap option changed
+ * between WordPress 5.6 & 5.7. In 5.8 the theme.json will most likely be supported and this won't be
+ * necessary any longer.
+ */
+function disable_drop_cap_setting() {
+	global $wp_version;
+
+	if ( version_compare( $wp_version, '5.7', '>=' ) ) {
+		add_filter( 'block_editor_settings', 'disable_drop_cap_editor_settings_5_7' );
+	}
+
+	if (
+		version_compare( $wp_version, '5.6', '>=' ) &&
+		version_compare( $wp_version, '5.7', '<' )
+	) {
+		add_filter( 'block_editor_settings', 'disable_drop_cap_editor_settings_5_6' );
+	}
+}
+
+/**
+ * Disable the drop cap setting for WordPress 5.7 +
+ *
+ * @param array $editor_settings block editor settings
+ */
+function disable_drop_cap_editor_settings_5_7( $editor_settings ) {
+	$editor_settings['__experimentalFeatures']['defaults']['typography']['dropCap'] = false;
+	return $editor_settings;
+}
+
+/**
+ * Disable the drop cap setting for WordPress 5.6
+ *
+ * @param array $editor_settings block editor settings
+ */
+function disable_drop_cap_editor_settings_5_6( $editor_settings ) {
+	$editor_settings['__experimentalFeatures']['global']['typography']['dropCap'] = false;
+	return $editor_settings;
 }


### PR DESCRIPTION
This will only work for WordPress 5.6 & 5.7 and is likely going to need an update for 5.8 again.

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

With this PR I am removing the DropCap option from the sidebar of the `core/paragraph` block.

The DropCap setting can get disabled via the theme.json file. Since this mechanism currently is only available in the Gutenberg Plugin there is a way to filter these setting in core. Since the theme.json format is still experimental however the format for disabling the dropCap option changed between WordPress 5.6 & 5.7. In 5.8 the theme.json will most likely be supported and this won't be necessary any longer.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [X] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
Removed DropCap option of Core Paragraph block by default.