### PR TITLE
Add `visually-hidden` utility class and Skip To Content link

### DIFF
--- a/themes/10up-theme/assets/css/frontend/base/index.css
+++ b/themes/10up-theme/assets/css/frontend/base/index.css
@@ -1,2 +1,3 @@
 @import url("prefers-reduced-motion.css");
 @import url("wordpress.css");
+@import url("utils.css");

--- a/themes/10up-theme/assets/css/frontend/base/utils.css
+++ b/themes/10up-theme/assets/css/frontend/base/utils.css
@@ -1,8 +1,5 @@
-/**
- * Text meant only for screen readers
- * Source: https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/
- */
-.screen-reader-text {
+.visually-hidden,
+.visually-hidden-focusable:not(:focus):not(:active) {
 	border: 0;
 	clip: rect(1px, 1px, 1px, 1px);
 	clip-path: inset(50%);
@@ -13,21 +10,4 @@
 	position: absolute;
 	width: 1px;
 	word-wrap: normal !important;
-
-	&:focus {
-		background-color: var(--c-white);
-		clip: auto !important;
-		clip-path: none;
-		color: var(--c-black);
-		display: block;
-		font-size: 1em;
-		height: auto;
-		left: 5px;
-		line-height: normal;
-		padding: 15px 23px 14px;
-		text-decoration: none;
-		top: 5px;
-		width: auto;
-		z-index: 100000; /* Above WP toolbar. */
-	}
 }

--- a/themes/10up-theme/assets/css/frontend/base/utils.css
+++ b/themes/10up-theme/assets/css/frontend/base/utils.css
@@ -1,0 +1,33 @@
+/**
+ * Text meant only for screen readers
+ * Source: https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/
+ */
+.screen-reader-text {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+	word-wrap: normal !important;
+
+	&:focus {
+		background-color: var(--c-white);
+		clip: auto !important;
+		clip-path: none;
+		color: var(--c-black);
+		display: block;
+		font-size: 1em;
+		height: auto;
+		left: 5px;
+		line-height: normal;
+		padding: 15px 23px 14px;
+		text-decoration: none;
+		top: 5px;
+		width: auto;
+		z-index: 100000; /* Above WP toolbar. */
+	}
+}

--- a/themes/10up-theme/assets/css/frontend/components/index.css
+++ b/themes/10up-theme/assets/css/frontend/components/index.css
@@ -1,1 +1,2 @@
 /* Components */
+@import url("skip-to-content-link.css");

--- a/themes/10up-theme/assets/css/frontend/components/skip-to-content-link.css
+++ b/themes/10up-theme/assets/css/frontend/components/skip-to-content-link.css
@@ -1,0 +1,5 @@
+.skip-to-content-link {
+	left: 0.3125rem;
+	position: absolute;
+	top: 0.3125rem;
+}

--- a/themes/10up-theme/assets/css/frontend/style.css
+++ b/themes/10up-theme/assets/css/frontend/style.css
@@ -23,7 +23,7 @@
 
 /* Components */
 
-/* @import url("components/index.css"); */
+@import url("components/index.css");
 
 /* Gutenberg blocks */
 

--- a/themes/10up-theme/footer.php
+++ b/themes/10up-theme/footer.php
@@ -6,6 +6,8 @@
  */
 
 ?>
-	<?php wp_footer(); ?>
+		</main>
+
+		<?php wp_footer(); ?>
 	</body>
 </html>

--- a/themes/10up-theme/header.php
+++ b/themes/10up-theme/header.php
@@ -16,7 +16,7 @@
 	<body <?php body_class(); ?>>
 		<?php wp_body_open(); ?>
 
-		<a href="#main" class="screen-reader-text"><?php echo esc_html_e( 'Skip to main content', 'tenup-theme' ); ?></a>
+		<a href="#main" class="skip-to-content-link visually-hidden-focusable"><?php echo esc_html_e( 'Skip to main content', 'tenup-theme' ); ?></a>
 
 		<main id="main" role="main" tabindex="-1">
 

--- a/themes/10up-theme/header.php
+++ b/themes/10up-theme/header.php
@@ -15,4 +15,9 @@
 	</head>
 	<body <?php body_class(); ?>>
 		<?php wp_body_open(); ?>
-		<h1><?php bloginfo( 'name' ); ?></h1>
+
+		<a href="#main" class="screen-reader-text"><?php echo esc_html_e( 'Skip to main content', 'tenup-theme' ); ?></a>
+
+		<main id="main" role="main" tabindex="-1">
+
+			<h1><?php bloginfo( 'name' ); ?></h1>


### PR DESCRIPTION
### Description of the Change

This PR adds support for `visually-hidden` and `visually-hidden-focusable` utility classes and "Skip to content link". It also replaces this PR: https://github.com/10up/wp-scaffold/pull/42

Using `visually-hidden` and not `screen-reader-text` for a few reasons:

- WordPress 5.8 also has the `screen-reader-text` in `common.css` which is loaded on the front end if you use default block styles. That would be ok, but the core class has opinionated `:focus` styles. https://github.com/WordPress/WordPress/blob/270f2011f8ec7265c3f4ddce39c77ef5b496ed1c/wp-admin/css/common.css#L146-L164 This means we'll have to override it in a theme, which isn't the cleanest approach.
- `visually-hidden` arguably seems to be a standard in a FE world:
  - https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/
  - https://www.sarasoueidan.com/blog/accessible-icon-buttons/
  - https://getbootstrap.com/docs/5.0/helpers/visually-hidden/

### Verification Process

- Verified that all elements with `.visually-hidden` class are hidden visually but announced by screen readers.
- Verified that all elements with `.visually-hidden-focusable` class are hidden visually but announced by screen readers and visible when they receive focus.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
