### PR TITLE
Add .eslintignore to theme

### DIFF
--- a/mu-plugins/10up-plugin/.eslintignore
+++ b/mu-plugins/10up-plugin/.eslintignore
@@ -2,5 +2,4 @@ assets/js/vendor
 assets/js/admin/vendor
 assets/js/frontend/vendor
 assets/js/shared/vendor
-webpack.config.babel.js
 tests

--- a/themes/10up-theme/.eslintignore
+++ b/themes/10up-theme/.eslintignore
@@ -1,0 +1,6 @@
+assets/js/vendor
+assets/js/admin/vendor
+assets/js/frontend/vendor
+assets/js/shared/vendor
+webpack.config.babel.js
+tests

--- a/themes/10up-theme/.eslintignore
+++ b/themes/10up-theme/.eslintignore
@@ -2,5 +2,4 @@ assets/js/vendor
 assets/js/admin/vendor
 assets/js/frontend/vendor
 assets/js/shared/vendor
-webpack.config.babel.js
 tests


### PR DESCRIPTION
### Description of the Change

Copy `.eslintignore` from the plugin directory and drop it into the theme directory. 

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.

### Applicable Issues

#37 

### Changelog Entry

Add .eslintignore to the theme directory
Remove webpack.config.babel.js from .eslintignore in the plugin directory
