### PR TITLE
Fix deprecation warnings for block.json structure

### DIFF
--- a/themes/10up-theme/includes/blocks/example-block/block.json
+++ b/themes/10up-theme/includes/blocks/example-block/block.json
@@ -26,7 +26,6 @@
 		},
 		"customClassName": false,
 		"defaultStylePicker": false,
-		"fontSize": false,
 		"html": false,
 		"inserter": true,
 		"lineHeight": true,
@@ -34,6 +33,9 @@
 		"reusable": false,
 		"spacing": {
 			"padding": false
+		},
+		"typography": {
+			"fontSize": false
 		}
 	},
 	"editorScript": "file:../../../dist/blocks/example-block/editor.js"

--- a/themes/10up-theme/includes/blocks/example-block/block.json
+++ b/themes/10up-theme/includes/blocks/example-block/block.json
@@ -28,14 +28,14 @@
 		"defaultStylePicker": false,
 		"html": false,
 		"inserter": true,
-		"lineHeight": true,
 		"multiple": true,
 		"reusable": false,
 		"spacing": {
 			"padding": false
 		},
 		"typography": {
-			"fontSize": false
+			"fontSize": false,
+			"lineHeight": true
 		}
 	},
 	"editorScript": "file:../../../dist/blocks/example-block/editor.js"


### PR DESCRIPTION
### Description of the Change

Fixes deprecation warnings for the `block.json` file structure when used with WordPress 5.8

### Verification Process

1. Set `WP_DEBUG` to `true` in wp-config.php
2. Navigated to wp-admin to see deprecation warnings
3. Fixed block.json structure and refreshed the page
4. Go to Pages > Add New
5. Inserted example-block into the editor to check for Font Size picker

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.

### Applicable Issues

#53 

### Changelog Entry

Changed structure of block.json to support new typography object with `fontSize` and `lineHeight`
