### PR TITLE
Change deprecated block_categories filter to block_categories_all

### DIFF
--- a/themes/10up-theme/includes/blocks.php
+++ b/themes/10up-theme/includes/blocks.php
@@ -22,7 +22,7 @@ function setup() {
 
 	add_action( 'enqueue_block_editor_assets', $n( 'blocks_editor_styles' ) );
 
-	add_filter( 'block_categories', $n( 'blocks_categories' ), 10, 2 );
+	add_filter( 'block_categories_all', $n( 'blocks_categories' ), 10, 2 );
 
 	add_action( 'init', $n( 'register_theme_blocks' ) );
 
@@ -93,12 +93,12 @@ function blocks_editor_styles() {
  * Filters the registered block categories.
  *
  * @param array  $categories Registered categories.
- * @param object $post       The post object.
+ * @param object $block_editor_context The current block editor context.
  *
  * @return array Filtered categories.
  */
-function blocks_categories( $categories, $post ) {
-	if ( ! in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
+function blocks_categories( $categories, $block_editor_context ) {
+	if ( ! in_array( $block_editor_context->post->post_type, array( 'post', 'page' ), true ) ) {
 		return $categories;
 	}
 

--- a/themes/10up-theme/includes/blocks.php
+++ b/themes/10up-theme/includes/blocks.php
@@ -92,16 +92,11 @@ function blocks_editor_styles() {
 /**
  * Filters the registered block categories.
  *
- * @param array  $categories Registered categories.
- * @param object $block_editor_context The current block editor context.
+ * @param array $categories Registered categories.
  *
  * @return array Filtered categories.
  */
-function blocks_categories( $categories, $block_editor_context ) {
-	if ( ! in_array( $block_editor_context->post->post_type, array( 'post', 'page' ), true ) ) {
-		return $categories;
-	}
-
+function blocks_categories( $categories ) {
 	return array_merge(
 		$categories,
 		array(


### PR DESCRIPTION
### Description of the Change

Fixes warning saying that `block_categories` has been deprecated in favor of `block_categories_all`.

https://developer.wordpress.org/reference/hooks/block_categories/

https://developer.wordpress.org/reference/hooks/block_categories_all/

### Verification Process

1. Set `WP_DEBUG` to `true` in wp-config.php
2. Go to the block editor in wp-admin
2. Select the main block inserter on the top left of the screen
3. Scroll to the bottom of the block list looking for the Custom Blocks category

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.

### Applicable Issues

#55 

### Changelog Entry

Changed filter `block_categories` to `block_categories_all`
