### PR TITLE
add `Update URI` header field to 10up-plugin-loader.php

### DIFF
--- a/mu-plugins/10up-plugin-loader.php
+++ b/mu-plugins/10up-plugin-loader.php
@@ -11,6 +11,7 @@
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       tenup-plugin
  * Domain Path:       /languages
+ * Update URI:        https://github.com/10up/wp-scaffold
  *
  * @package           TenUpPlugin
  */


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This adds the `Update URI` header field in the scaffold plugin main PHP file.  Ideally all plugins generated from this update to their own link but even pointing to ANYWHERE is better than nothing and will block unwanted plugin updates from name conflicts on WP.org.

### Alternate Designs

n/a

### Benefits

avoid inaccurate plugin updates from WP.org name collisions

### Possible Drawbacks

none identified

### Verification Process

n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

n/a
