### PR TITLE
Feature: Add font sizes values from core into theme json

### DIFF
--- a/themes/10up-theme/theme.json
+++ b/themes/10up-theme/theme.json
@@ -24,7 +24,33 @@
       "customFontSize": false,
       "customLineHeight": false,
       "dropCap": false,
-      "fontSizes": []
+      "fontSizes": [
+        {
+          "name": "Small",
+          "slug": "small",
+          "size": "13px"
+        },
+        {
+          "name": "Normal",
+          "slug": "normal",
+          "size": "16px"
+        },
+        {
+          "name": "Medium",
+          "slug": "medium",
+          "size": "20px"
+        },
+        {
+          "name": "Large",
+          "slug": "large",
+          "size": "36px"
+        },
+        {
+          "name": "Huge",
+          "slug": "huge",
+          "size": "42px"
+        }
+      ]
     },
     "blocks": {
       "core/button": {


### PR DESCRIPTION
### Description of the Change

This PR adds the font size values defined in core to the theme scaffold.
The core font sizes were retrieved from here: https://github.com/WordPress/gutenberg/blob/26556937b70bbf4aaef8c112321703b61a740284/lib/theme.json#L196-L222

### Alternate Designs

My original goal was to override a single core font size while leaving the other values intact, but this isn't possible.

### Benefits

- The font sizes that are available in Gutenberg by default will now be available to themes using the scaffold.
- Default font sizes supported by WordPress will now be listed in our `theme.json`, making it easier to customize them.
- Individual font size options can now be customized, without losing the other WP core font sizes.

### Possible Drawbacks

- Detaches our theme's font sizes from the font sizes defined in WP core.

### Verification Process

1. Installed a copy of the theme at `trunk` and confirmed that no font size options are availalble.
2. Made changes, rebuilt the theme, and confirmed that the font sizes I added were available.
3. Tried customizing a single font size option and was able to do so without losing or changing the other options.

### Checklist:

- N/A I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Relates to a conversation in Slack where I was trying to make changes to a single font size option, without losing the other WP core font size options.
https://10up.slack.com/archives/C8Z3WMN1K/p1638295806165800

### Changelog Entry

Adds the default font-size options defined in core to the scaffold's theme.json file.