### PR TITLE
Feature/extend style guide color formats

### DIFF
--- a/themes/10up-theme/assets/css/styleguide/styleguide.css
+++ b/themes/10up-theme/assets/css/styleguide/styleguide.css
@@ -4,6 +4,8 @@
 	--c-uikit-hightlight: #f6f6f6;
 	--c-uikit-border: #ccc;
 	--c-uikit-primary: #000;
+	--c-uikit-color-label: #000;
+	--c-uikit-color-label-bg: #fff;
 
 	@custom-media --bp-uikit-small (min-width: 40.625em);
 
@@ -42,32 +44,46 @@
 }
 
 .uikit__colors {
+	align-items: center;
+	display: flex;
+	flex-flow: row wrap;
 	font-family: "Courier New", monospace;
+	gap: 32px;
 	list-style: none;
-	margin: 0;
+	margin: 0 auto;
 	overflow: hidden;
 	padding: 0;
 	text-align: center;
-}
 
-.uikit__color {
-	align-items: center;
-	border: 1px solid var(--c-uikit-border);
-	display: flex;
-	float: left;
-	font-size: 0.85em;
-	height: 90px;
-	justify-content: center;
-	margin-bottom: 32px;
-	margin-right: 32px;
-	width: 90px;
+	& > li.uikit__color {
+		align-items: center;
+		border: 1px solid var(--c-uikit-border);
+		display: flex;
+		flex: 0 0 auto;
+		font-size: 0.85em;
+		height: 90px;
+		justify-content: center;
+		margin: 0;
+		width: 90px;
+
+		&:focus,
+		&:hover {
+
+			& .uikit__color--label {
+				left: auto;
+			}
+		}
+	}
 }
 
 .uikit__color--label {
-	color: var(--c-primary);
+	background: var(--c-uikit-color-label-bg);
+	border: 1px solid var(--c-uikit-border);
+	color: var(--c-uikit-color-label);
+	font-size: var(--fs-xxs, 12px);
 	left: -999em;
 	margin: 0;
-	padding: 0;
+	padding: 0.5em;
 	position: absolute;
 }
 

--- a/themes/10up-theme/includes/utility.php
+++ b/themes/10up-theme/includes/utility.php
@@ -48,6 +48,8 @@ function get_colors( $path ) {
 	if ( file_exists( $dir . $path ) ) {
 		$css_vars = file_get_contents( $dir . $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions
 		preg_match_all( ' /#([a-f]|[A-F]|[0-9]){3}(([a-f]|[A-F]|[0-9]){3})?\b/', $css_vars, $matches );
+		// HEX | RGB(A) | HSL(A)
+		preg_match_all( '(#([\da-f]{3}){1,2}|(rgb|hsl)a\((\d{1,3}%?,\s?){3}(1|0?\.\d+)\)|(rgb|hsl)\(\d{1,3}%?(,\s?\d{1,3}%?){2}\))', $css_vars, $matches );
 		return $matches[0];
 	}
 


### PR DESCRIPTION
### Description of the Change

Updated the scaffold style guide colours section to support additional colour formats

- HEX
- RGB(A)
- HSL(A)

And to ensure the colour values are displayed on hover of the colour swatch

Closes https://github.com/10up/wp-scaffold/issues/90

### Alternate Designs

This follows the existing approach and simply extends the RegEx already in place.

### Possible Drawbacks

None anticipated.

### Verification Process

- Updated colors.css with HEX, RGB, RGBA, HSL and HSLA values and verified they displayed as expected within the style guide
- Verified the correct colour value displays on hover of the colour swatch within the style guide

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Updated
- PHP utility function get_colors() RegEx
- styleguide.css
