### PR TITLE
Fix: Escaping of block wrapper attributes function

### DIFF
--- a/themes/10up-theme/includes/blocks.php
+++ b/themes/10up-theme/includes/blocks.php
@@ -68,8 +68,7 @@ function register_theme_blocks() {
 				$block_options['render_callback'] = function( $attributes, $content, $block ) use ( $block_folder ) {
 
 					// create helpful variables that will be accessible in markup.php file
-					$context            = $block->context;
-					$wrapper_attributes = wp_kses_post( get_block_wrapper_attributes() );
+					$context = $block->context;
 
 					// get the actual markup from the markup.php file
 					ob_start();

--- a/themes/10up-theme/includes/blocks/example-block/markup.php
+++ b/themes/10up-theme/includes/blocks/example-block/markup.php
@@ -9,11 +9,10 @@
  * @var WP_Block $block              Block instance.
  * @var array    $context            BLock context.
  * @var string   $class_name         Generated class name for concatenation.
- * @var string   $wrapper_attributes Block Wrapper Attributes. To be applied to the outermost element.
  */
 
 ?>
-<div <?php echo wp_kses_post( $wrapper_attributes ); ?>">
+<div <?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>">
 	<h2 class="<?php echo sanitize_html_class( $class_name ); ?>__title">
 		<?php echo wp_kses_post( $attributes['title'] ); ?>
 	</h2>

--- a/themes/10up-theme/includes/blocks/example-block/markup.php
+++ b/themes/10up-theme/includes/blocks/example-block/markup.php
@@ -8,12 +8,11 @@
  * @var string   $content            Block content.
  * @var WP_Block $block              Block instance.
  * @var array    $context            BLock context.
- * @var string   $class_name         Generated class name for concatenation.
  */
 
 ?>
 <div <?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>">
-	<h2 class="<?php echo sanitize_html_class( $class_name ); ?>__title">
+	<h2 class="wp-block-tenup-example__title">
 		<?php echo wp_kses_post( $attributes['title'] ); ?>
 	</h2>
 </div>


### PR DESCRIPTION
Removes the incorrect triple escaping of the `get_block_wrapper_attributes` function
