### PR TITLE
Remove remnant quotation mark in attribute

### DIFF
--- a/themes/10up-theme/includes/blocks/example-block/markup.php
+++ b/themes/10up-theme/includes/blocks/example-block/markup.php
@@ -11,7 +11,7 @@
  */
 
 ?>
-<div <?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>">
+<div <?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>>
 	<h2 class="wp-block-tenup-example__title">
 		<?php echo wp_kses_post( $attributes['title'] ); ?>
 	</h2>


### PR DESCRIPTION
A tiny change, I've noticed an extra `"` in the block markup.