### PR TITLE
fix traverse blocks in theme.json to get colors that aren’t used in global palette

### DIFF
--- a/themes/10up-theme/tailwind.config.js
+++ b/themes/10up-theme/tailwind.config.js
@@ -5,6 +5,24 @@ const themeJSON = require('./theme.json');
 function getThemePalette() {
 	const { palette } = themeJSON.settings.color;
 
+	// get the color palette for any blocks that have a color palette
+	Object.values(themeJSON.blocks ?? {}).forEach((block) => {
+		const { palette: blockPalette } = block.color;
+
+		if (!blockPalette || !Array.isArray(blockPalette)) {
+			return;
+		}
+
+		blockPalette.forEach((paletteColor) => {
+			const { slug } = paletteColor;
+
+			const isExistingColor = palette.find((color) => color.slug === slug);
+			if (!isExistingColor) {
+				palette.push(paletteColor);
+			}
+		});
+	});
+
 	return Array.isArray(palette) ? palette : [];
 }
 


### PR DESCRIPTION
### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

Ensure any colors that may only be used in a block color palette in the `theme.json` also get added to the tailwind color config. See https://github.com/10up/wp-scaffold/pull/121#discussion_r868958442