### PR TITLE
Adds screenreader arg to main button

### DIFF
--- a/themes/10up-theme/templates/page-button-sink.php
+++ b/themes/10up-theme/templates/page-button-sink.php
@@ -16,6 +16,7 @@ if ( function_exists( 'UIKit\Helpers\get_component' ) ) :
 			'buttons' => [
 				[
 					'label' => 'Read more',
+					'screenreader' => 'about this educational topic',
 				],
 			],
 		]


### PR DESCRIPTION
### Description of the Change

This feature adds the screenreader prop to the primary button in the page-button-sink.php template.

### Verification Process

- Checkout this branch
- Checkout trunk from the 10up-ui-kit repo
- Preview the template on the frontend and inspect for the screenreader text to be passed through to the label of the first button

### Checklist:
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
