### PR TITLE
Adds dark and light background colors to button sink

### DIFF
--- a/themes/10up-theme/templates/page-button-sink.php
+++ b/themes/10up-theme/templates/page-button-sink.php
@@ -848,10 +848,24 @@ get_header();
 					echo wp_kses_post( $dark_button );
 				?>
 
+				<h3 class="heading">On light background</h3>
+				<div style="background-color: #e7e7e7; padding: 1rem;">
+					<?php
+						echo wp_kses_post( $dark_button );
+					?>
+				</div>
+
 				<h3 class="heading">Light Button</h3>
 				<?php
 					echo wp_kses_post( $light_button );
 				?>
+
+				<h3 class="heading">On dark background</h3>
+				<div class="has-dark-background-color" style="padding: 1rem;">
+					<?php
+						echo wp_kses_post( $light_button );
+					?>
+				</div>
 			</div>
 		</section>
 


### PR DESCRIPTION
### Description of the Change

This feature adds 2 button examples to the page-button-sink.php template. 
- On light background
- On dark background

In addition, it adds a light border setting to the light button on hover and active, in order that it may be visible on a darkened background. This now works opposite of the dark button, which received a dark border on hover.

### Verification Process

- Checkout this branch
- Checkout trunk in the https://github.com/10up/10up-ui-kit repo
- Run the dev workflow
- Verify on the front end that these 2 variants are working as expected