### PR TITLE
Workspaces friendlier packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This scaffold is the starting point for all 10up WordPress projects.
 
-It contains a bare bones theme and must use plugin for you to base your development off of. Asset bundling is handled entirely by [10up Toolkit](https://github.com/10up/10up-toolkit).
+It contains a bare-bones theme and must use plugin for you to base your development off of. Asset bundling is handled entirely by [10up Toolkit](https://github.com/10up/10up-toolkit).
 
 ## Requirements
 
@@ -25,15 +25,15 @@ It contains a bare bones theme and must use plugin for you to base your developm
   ],
 ```
 6. To build plugins/themes simply run `npm install` at the root and `npm run [build|start|watch]` and npm will automatically build all themes and plugins.
-7. `npm workspaces` do not have the ability to run scripts from multiple packages in parrallel. Because of that we use the `npm-run-all` package and we define specific scripts in `package.json` so you will need to update the `watch:*` scripts in `package.json` and replace `tenup-theme` and `tenup-plugin` with the actual package names.
+7. `npm workspaces` do not have the ability to run scripts from multiple packages in parallel. Because of that we use the `npm-run-all` package and we define specific scripts in `package.json` so you will need to update the `watch:*` scripts in `package.json` and replace `tenup-theme` and `tenup-plugin` with the actual package names.
 
 ```json
 	"watch:theme": "npm run watch -w=tenup-theme",
 	"watch:plugin": "npm run watch -w=tenup-plugin",
 	"watch": "run-s watch:theme watch:plugin",
 ```
-7. To add npm dependencies to your theme and/or plugins add the `-w=package-name` flag to the `npm install` command. E.g: `npm install --save prop-types -w=tenup-plugin` **DO NOT RUN** `npm install` inside an individual workspace/package. Always run the from the root folder.
-8. If you're building Gutenberg blocks and importing `@wordpress/*` packages, **you do not** need to manually install them as `10up-toolkit` will handle these packages properly.
+7. To add npm dependencies to your theme and/or plugins add the `-w=package-name` flag to the `npm install` command. E.g: `npm install --save prop-types -w=tenup-plugin`. **DO NOT RUN** `npm install` inside an individual workspace/package. Always run it from the root folder.
+8. If you're building Gutenberg blocks and importing `@wordpress/*` packages, **you do not** need to manually install them as `10up-toolkit` will handle these packages properly. However, it might still be a good idea for intellisense and code completion.
 
 ## Scaffold Rules
 

--- a/mu-plugins/10up-plugin/.npmrc
+++ b/mu-plugins/10up-plugin/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+package-lock=false

--- a/mu-plugins/10up-plugin/package.json
+++ b/mu-plugins/10up-plugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tenup-plugin",
   "version": "1.0.0",
+  "private": false,
   "scripts": {
     "start": "npm run watch",
     "watch": "10up-toolkit watch --port=5010 --hot",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tenup-wp-scaffold",
   "version": "1.0.0",
+  "private": false,
   "description": "Project Description",
   "homepage": "https://project-domain.tld",
   "repository": {

--- a/themes/10up-theme/.npmrc
+++ b/themes/10up-theme/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+package-lock=false

--- a/themes/10up-theme/package.json
+++ b/themes/10up-theme/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tenup-theme",
   "version": "1.0.0",
+  "private": false,
   "scripts": {
     "start": "npm run watch",
     "watch": "10up-toolkit watch --port=5000 --hot",


### PR DESCRIPTION
### Description of the Change

The main purpose of this change was to make sure that `package-lock` files can't be created within internal packages. Related is some package.json tweak to avoid publishing packages by mistake and also some housekeeping around the README file.

### Checklist:

- [X] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my change.
- [X] All new and existing tests passed.
