### PR TITLE
add scaffold for link and button style to help engineers with editor style bleed

### DIFF
--- a/themes/10up-theme/assets/css/frontend/base/button.css
+++ b/themes/10up-theme/assets/css/frontend/base/button.css
@@ -2,7 +2,7 @@
  * Ensure that we are not overriding the editor styles of the
  * WordPress Components.
  *
- * This is a workarround for: https://github.com/WordPress/gutenberg/issues/10178
+ * This is a workaround for: https://github.com/WordPress/gutenberg/issues/10178
  *
  * using :where to prevent the specificity increase of using :not
  */

--- a/themes/10up-theme/assets/css/frontend/base/button.css
+++ b/themes/10up-theme/assets/css/frontend/base/button.css
@@ -1,0 +1,11 @@
+/*
+ * Ensure that we are not overriding the editor styles of the
+ * WordPress Components.
+ *
+ * This is a workarround for: https://github.com/WordPress/gutenberg/issues/10178
+ *
+ * using :where to prevent the specificity increase of using :not
+ */
+button:where(:not(.components-button)) {
+
+}

--- a/themes/10up-theme/assets/css/frontend/base/index.css
+++ b/themes/10up-theme/assets/css/frontend/base/index.css
@@ -1,3 +1,5 @@
 @import url("prefers-reduced-motion.css");
 @import url("wordpress.css");
 @import url("utils.css");
+@import url("button.css");
+@import url("link.css");

--- a/themes/10up-theme/assets/css/frontend/base/link.css
+++ b/themes/10up-theme/assets/css/frontend/base/link.css
@@ -2,7 +2,7 @@
  * Ensure that we are not overriding the editor styles of the
  * WordPress Components.
  *
- * This is a workarround for: https://github.com/WordPress/gutenberg/issues/10178
+ * This is a workaround for: https://github.com/WordPress/gutenberg/issues/10178
  *
  * using :where to prevent the specificity increase of using :not
  */

--- a/themes/10up-theme/assets/css/frontend/base/link.css
+++ b/themes/10up-theme/assets/css/frontend/base/link.css
@@ -1,0 +1,11 @@
+/*
+ * Ensure that we are not overriding the editor styles of the
+ * WordPress Components.
+ *
+ * This is a workarround for: https://github.com/WordPress/gutenberg/issues/10178
+ *
+ * using :where to prevent the specificity increase of using :not
+ */
+a:where(:not(.components-button)) {
+
+}

--- a/themes/10up-theme/assets/css/frontend/base/link.css
+++ b/themes/10up-theme/assets/css/frontend/base/link.css
@@ -6,6 +6,6 @@
  *
  * using :where to prevent the specificity increase of using :not
  */
-a:where(:not(.components-button)) {
+a:where(:not(.components-external-link)) {
 
 }


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description.  If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.  Also including any benefits that will be realized by the code change will be helpful.  Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

Add scaffold for link and button base CSS in order to help engineers work around introducing bleed of editor styles into the WordPress Admin interface. 

Since we have switched to using the [`add_editor_style`](https://developer.wordpress.org/reference/functions/add_editor_style/) function for including our editor styles in #69 we've found two common issues where base styles of link and button elements affect some instances of Block Editor components. This of course is not intended behavior and really should be fixed in WordPress core. See WordPress/gutenberg#10178 

To work around this I've gone ahead and added an empty shell for the link and button base styles so that they exclude the WordPress core elements. In order to not increase the specificity of the selector, we are using the `:where` pseudo-selector. 

<!-- Enter any applicable Issues here. Example: -->
Closes #

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

We in theory introduce a separate frontend-only stylesheet again to split the styles that should get applied in the editor apart. We've seen in the past however, that this quickly leads to many inconsistencies and editorial experiences that don't match the frontend appearance. 

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
The `:where` pseudo selector is currently supported in 90% of browsers according to [caniuse.com](https://caniuse.com/?search=%3Awhere). This should cover all the browsers we are targeting for client builds.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

- Add some custom styles to either the `link.css` files in the `assets/css/frontend/base` directory
- Navigate to the editor
- Insert a paragraph and add a link. -> See that the styles are showing up correctly 

- Insert an Image Block -> See on the Placeholder state that the link in the placeholder that is part of core does not get affected. 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed: Remove editor-style of links and buttons bleeding into Core WordPress elements

<!--
Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.
Example:
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
-->

