### PR TITLE
automated asset version

### DIFF
--- a/mu-plugins/10up-plugin/includes/core.php
+++ b/mu-plugins/10up-plugin/includes/core.php
@@ -135,7 +135,7 @@ function scripts() {
 		'tenup_plugin_shared',
 		script_url( 'shared', 'shared' ),
 		Utility\get_asset_info( 'shared', 'dependencies' ),
-		TENUP_PLUGIN_VERSION,
+		Utility\get_asset_info( 'shared', 'version' ),
 		true
 	);
 
@@ -143,7 +143,7 @@ function scripts() {
 		'tenup_plugin_frontend',
 		script_url( 'frontend', 'frontend' ),
 		Utility\get_asset_info( 'frontend', 'dependencies' ),
-		TENUP_PLUGIN_VERSION,
+		Utility\get_asset_info( 'frontend', 'version' ),
 		true
 	);
 
@@ -160,7 +160,7 @@ function admin_scripts() {
 		'tenup_plugin_shared',
 		script_url( 'shared', 'shared' ),
 		Utility\get_asset_info( 'shared', 'dependencies' ),
-		TENUP_PLUGIN_VERSION,
+		Utility\get_asset_info( 'shared', 'version' ),
 		true
 	);
 
@@ -168,7 +168,7 @@ function admin_scripts() {
 		'tenup_plugin_admin',
 		script_url( 'admin', 'admin' ),
 		Utility\get_asset_info( 'admin', 'dependencies' ),
-		TENUP_PLUGIN_VERSION,
+		Utility\get_asset_info( 'admin', 'version' ),
 		true
 	);
 
@@ -185,7 +185,7 @@ function styles() {
 		'tenup_plugin_shared',
 		style_url( 'shared', 'shared' ),
 		[],
-		TENUP_PLUGIN_VERSION
+		Utility\get_asset_info( 'shared', 'version' ),
 	);
 
 	if ( is_admin() ) {
@@ -193,14 +193,14 @@ function styles() {
 			'tenup_plugin_admin',
 			style_url( 'admin', 'admin' ),
 			[],
-			TENUP_PLUGIN_VERSION
+			Utility\get_asset_info( 'admin', 'version' ),
 		);
 	} else {
 		wp_enqueue_style(
 			'tenup_plugin_frontend',
 			style_url( 'frontend', 'frontend' ),
 			[],
-			TENUP_PLUGIN_VERSION
+			Utility\get_asset_info( 'frontend', 'version' ),
 		);
 	}
 
@@ -217,14 +217,14 @@ function admin_styles() {
 		'tenup_plugin_shared',
 		style_url( 'shared', 'shared' ),
 		[],
-		TENUP_PLUGIN_VERSION
+		Utility\get_asset_info( 'shared', 'version' ),
 	);
 
 	wp_enqueue_style(
 		'tenup_plugin_admin',
 		style_url( 'admin', 'admin' ),
 		[],
-		TENUP_PLUGIN_VERSION
+		Utility\get_asset_info( 'admin', 'version' ),
 	);
 
 }


### PR DESCRIPTION
### Description of the Change

update asset enqueue on `mu-plugin` folder with an automated version instead of `TENUP_PLUGIN_VERSION` constant  using `Utility\get_asset_info()` function.
Having this as a default in the template would help to refresh assets on each build

### How to test the Change

when assets are being enqueued, version should have the following format: `frontend.js?version=[dynamic_version]`

### Changelog Entry

Enqueue assets using automatic version coming from `Utility\get_asset_info()` function instead of plugin version constant.
> Changed - Existing functionality

### Credits
Props @hugosolar 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
