### PR TITLE
Update 10up-toolkit to version 4.3 and update blocks to use `useBlockAssets` feature

### DIFF
--- a/mu-plugins/10up-plugin/package.json
+++ b/mu-plugins/10up-plugin/package.json
@@ -15,7 +15,7 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
-    "10up-toolkit": "^4.2.0-next.0"
+    "10up-toolkit": "^4.3.0"
   },
   "dependencies": {
     "prop-types": "^15.7.2"

--- a/mu-plugins/10up-plugin/package.json
+++ b/mu-plugins/10up-plugin/package.json
@@ -15,7 +15,7 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
-    "10up-toolkit": "^4.1.1"
+    "10up-toolkit": "^4.2.0-next.0"
   },
   "dependencies": {
     "prop-types": "^15.7.2"

--- a/themes/10up-theme/functions.php
+++ b/themes/10up-theme/functions.php
@@ -13,6 +13,7 @@ define( 'TENUP_THEME_DIST_PATH', TENUP_THEME_PATH . 'dist/' );
 define( 'TENUP_THEME_DIST_URL', TENUP_THEME_TEMPLATE_URL . '/dist/' );
 define( 'TENUP_THEME_INC', TENUP_THEME_PATH . 'includes/' );
 define( 'TENUP_THEME_BLOCK_DIR', TENUP_THEME_INC . 'blocks/' );
+define( 'TENUP_THEME_BLOCK_DIST_DIR', TENUP_THEME_PATH . 'dist/blocks/' );
 
 $is_local_env = in_array( wp_get_environment_type(), [ 'local', 'development' ], true );
 $is_local_url = strpos( home_url(), '.test' ) || strpos( home_url(), '.local' );

--- a/themes/10up-theme/includes/blocks.php
+++ b/themes/10up-theme/includes/blocks.php
@@ -56,8 +56,8 @@ function register_theme_blocks() {
 	}
 
 	// Register all the blocks in the theme
-	if ( file_exists( TENUP_THEME_BLOCK_DIR ) ) {
-		$block_json_files = glob( TENUP_THEME_BLOCK_DIR . '*/block.json' );
+	if ( file_exists( TENUP_THEME_BLOCK_DIST_DIR ) ) {
+		$block_json_files = glob( TENUP_THEME_BLOCK_DIST_DIR . '*/block.json' );
 
 		// auto register all blocks that were found.
 		foreach ( $block_json_files as $filename ) {

--- a/themes/10up-theme/includes/blocks/example-block/block.json
+++ b/themes/10up-theme/includes/blocks/example-block/block.json
@@ -20,6 +20,5 @@
   "supports": {
     "html": false
   },
-  "editorScript": "file:./index.js",
-  "editorStyle": "file:./editor.css"
+  "editorScript": "file:./index.js"
 }

--- a/themes/10up-theme/includes/blocks/example-block/block.json
+++ b/themes/10up-theme/includes/blocks/example-block/block.json
@@ -20,6 +20,6 @@
   "supports": {
     "html": false
   },
-  "editorScript": "file:../../../dist/blocks/example-block/editor.js",
-  "editorStyle": "file:../../../dist/blocks/example-block/editor.css"
+  "editorScript": "file:./index.js",
+  "editorStyle": "file:./editor.css"
 }

--- a/themes/10up-theme/includes/blocks/example-block/edit.js
+++ b/themes/10up-theme/includes/blocks/example-block/edit.js
@@ -4,9 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 
-// Importing the block's editor styles via JS will enable hot reloading for css
-import './editor.css';
-
 /**
  * Edit component.
  * See https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-edit-save/#edit

--- a/themes/10up-theme/includes/blocks/example-block/editor.css
+++ b/themes/10up-theme/includes/blocks/example-block/editor.css
@@ -1,9 +1,0 @@
-/**
- * Example Block
- * This file is for CSS admin overrides only.
- * Use theme files for standard CSS work.
- */
-.wp-block-example-block__title {
-	border: 3px dashed #ccc;
-	padding: 1em;
-}

--- a/themes/10up-theme/includes/blocks/example-block/index.js
+++ b/themes/10up-theme/includes/blocks/example-block/index.js
@@ -15,9 +15,6 @@ import edit from './edit';
 import save from './save';
 import block from './block.json';
 
-/* Uncomment for CSS overrides in the admin */
-// import './index.css';
-
 /**
  * Register block
  */

--- a/themes/10up-theme/package.json
+++ b/themes/10up-theme/package.json
@@ -15,20 +15,20 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
-    "10up-toolkit": "^4.1.1"
+    "10up-toolkit": "^4.2.0-next.0"
   },
   "dependencies": {
     "normalize.css": "^8.0.1"
   },
   "10up-toolkit": {
+    "useBlockAssets": true,
     "entry": {
       "admin": "./assets/js/admin/admin.js",
       "editor-style-overrides": "./assets/js/admin/editor-style-overrides.js",
       "frontend": "./assets/js/frontend/frontend.js",
       "shared": "./assets/js/shared/shared.js",
       "styleguide": "./assets/js/styleguide/styleguide.js",
-      "core-block-overrides": "./includes/core-block-overrides.js",
-      "example-block": "./includes/blocks/example-block/index.js"
+      "core-block-overrides": "./includes/core-block-overrides.js"
     }
   }
 }

--- a/themes/10up-theme/package.json
+++ b/themes/10up-theme/package.json
@@ -15,7 +15,7 @@
     "node": ">=12.0.0"
   },
   "devDependencies": {
-    "10up-toolkit": "^4.2.0-next.0"
+    "10up-toolkit": "^4.3.0"
   },
   "dependencies": {
     "normalize.css": "^8.0.1"


### PR DESCRIPTION
in version 4.2 of toolkit the way block assets get handled got updated to use asset keys from the individual block.json file for entrypoint management

See: 10up/10up-toolkit#195