### PR TITLE
Example Block: Remove tabs

### DIFF
--- a/themes/10up-theme/includes/blocks/example-block/block.json
+++ b/themes/10up-theme/includes/blocks/example-block/block.json
@@ -1,16 +1,16 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 2,
-	"title": "Example Block",
-	"description": "An Example Block",
-	"textdomain": "tenup-theme",
-	"name": "tenup/example",
+  "title": "Example Block",
+  "description": "An Example Block",
+  "textdomain": "tenup-theme",
+  "name": "tenup/example",
   "icon": "feedback",
   "category": "tenup-theme-blocks",
-	"attributes":{
-		"title": {
-			"type" : "string"
-		}
+  "attributes":{
+    "title": {
+      "type" : "string"
+    }
   },
   "example": {
     "attributes":{


### PR DESCRIPTION
Removed cases where tabs are used instead of spaces for indenting, so that the spacing of the file is consistent.

<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
The `block.json` file for the example block inconsistently uses tabs and spaces for indentation. I've fixed any cases where tabs are being used, as the majority of the document was using spaces before this fix.

This fixes an issue where indenting would appear inconsistent on platforms like GitLab / GitHub when viewing assets.

### How to test the Change
Open `themes/10up-theme/includes/blocks/example-block/block.json` in your editor of choice and confirm that all indentation uses a consistent character.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix
Example Block: Fix instances where tabs were being mixed with spaces for indentation in `block.json`

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @roseg43 (wasn't sure if I should add myself, so here I am 😂)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
