### PR TITLE
Feature/auto initialize modules

### DIFF
--- a/docs/registering-classes.md
+++ b/docs/registering-classes.md
@@ -1,0 +1,150 @@
+# Registering Classes in the MU-Plugin
+
+The MU-Plugin utilizes a system to uniformly, auto-register classes that lie within its namespace. Whilst there are a few constraints, it eases the requirements for engineers to add their classes to multiple locations each time they add one to the system.
+
+To do this, it uses the [haydenpierce/class-finder](https://packagist.org/packages/haydenpierce/class-finder) package, which reads the `composer.json` file to help locate files that belong in certain namespaces.
+
+## How do I define a class to be auto-registered?
+
+All you need to do to get a class to auto-register is extend the `TenUpPlugin\Module::class` class. That will require you to implement a `can_register()` and a `register()` method.
+
+### `can_register()`
+
+The `can_register()` method is used to decide whether a class should be registered or not. Some examples of valid `can_register()` methods are:
+
+#### Always Register
+
+```php
+public function can_register() {
+    return true;
+}
+```
+
+#### Register if in the admin area
+
+```php
+public function can_register() {
+    return is_admin();
+}
+```
+
+#### Register if a specific plugin is active
+
+```php
+public function can_register() {
+    return plugin_active( 'plugin-directory/plugin-name.php' );
+}
+```
+
+#### Register if running via WP-CLI
+
+```php
+public function can_register() {
+    return defined( 'WP_CLI' ) && WP_CLI;
+}
+```
+
+As you can hopfully see, it's easy enough to do everything we could previously with this approach.
+
+### `register()`
+
+The `register()` method is where you hook in to do your actual logic, E.G. adding `add_action()` or `add_filter()` calls. Your `register()` methods should look something like:
+
+```php
+public function register() {
+    add_action( 'init', [ $this, 'register_post_types' ] );
+}
+```
+
+One thing worth noting is that the `register()` method will be called at the priority of `8`. This means that you can use the priorty default of `10` or hook in earlier at `9` if you need to.
+
+### Putting it all together
+
+Below is a sample of a class that would be auto-registered when in the admin area, used to register some settings via FieldManager:
+
+```php
+namespace TenUpPlugin\Admin;
+
+/**
+ * Provide a Site Settings screen.
+ */
+class SiteSettings extends \TenUpPlugin\Module {
+
+	/**
+	 * Fieldmanager Setting ID
+	 *
+	 * @var string
+	 */
+	public $name = 'site_settings';
+
+	/**
+	 * Only register if on an admin page and if fieldmanager plugin is active.
+	 *
+	 * @return bool
+	 */
+	public function can_register() {
+		return is_admin() && function_exists( 'fm_register_submenu_page' );
+	}
+
+	/**
+	 * Register our hooks.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		add_action( 'init', [ $this, 'register_site_settings' ] );
+	}
+
+	/**
+	 * Creates a new Site Settings Screen.
+	 *
+	 * @return void
+	 */
+	public function register_site_settings() {
+		// Register the submenu page.
+		fm_register_submenu_page(
+			$this->name,
+			'options-general.php',
+			__( 'Site Settings', 'tenup-plugin' )
+		);
+
+		// Load the fields.
+		add_action(
+			'fm_submenu_' . $this->name,
+			[ $this, 'load' ]
+		);
+	}
+
+	/**
+	 * Configures the site settings.
+	 *
+	 * @return void
+	 */
+	public function load() {
+		$config = [
+			'name'     => $this->name,
+			'children' => [
+				// FM field config.
+			],
+		];
+
+		$fm = new \Fieldmanager_Group( $config );
+		$fm->activate_submenu_page();
+	}
+}
+
+```
+
+
+
+## Known Issues
+
+### Could not locate `composer.json`
+
+During deployment, we must deploy the `composer.json` file. This is how the class finder works, so if it doesn't exist you'll get an exception that states:
+
+```
+Could not locate composer.json. You can get around this by setting ClassFinder::$appRoot manually.
+```
+
+More information on this issue is available [here](https://gitlab.com/hpierce1102/ClassFinder/-/blob/master/docs/exceptions/missingComposerConfig.md).

--- a/docs/registering-classes.md
+++ b/docs/registering-classes.md
@@ -135,6 +135,20 @@ class SiteSettings extends \TenUpPlugin\Module {
 
 ```
 
+## How do I get an instance of my registered class?
+
+The old way of doing this would be to use the `get_plugin_support()` function. As we no longer define and register our classes in the same way, this doesn't work.
+
+The best way now, is to use the `get_class()` method that's part of the `ModuleInitialization` class.
+
+```php
+$site_settings = \TenUpPlugin\ModuleInitialization::instance()->get_class( '\TenUpPlugin\Admin\SiteSettings' );
+```
+
+The ModuleInitialization class is a singleton, so you can use it to get an instance of any class that has been registered.
+If it can't find the class, it will return `false`.
+
+One major difference between the old way and the new way is that when calling the `get_class()` method, you pass in the class name as a string containing the class name with its full namespace.
 
 
 ## Known Issues

--- a/mu-plugins/10up-plugin/composer.json
+++ b/mu-plugins/10up-plugin/composer.json
@@ -8,7 +8,8 @@
     }
   ],
   "require": {
-    "php": ">=7.0"
+    "php": ">=7.0",
+    "haydenpierce/class-finder": "^0.4.3"
   },
   "autoload": {
     "psr-4": {

--- a/mu-plugins/10up-plugin/composer.json
+++ b/mu-plugins/10up-plugin/composer.json
@@ -14,6 +14,9 @@
   "autoload": {
     "psr-4": {
       "TenUpPlugin\\": "includes/classes/"
-    }
+    },
+    "files": [
+      "includes/helpers/helpers.php"
+    ]
   }
 }

--- a/mu-plugins/10up-plugin/composer.lock
+++ b/mu-plugins/10up-plugin/composer.lock
@@ -1,0 +1,66 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "c54b04ed0a79b4d1316a4107cedc984d",
+    "packages": [
+        {
+            "name": "haydenpierce/class-finder",
+            "version": "0.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://gitlab.com/hpierce1102/ClassFinder.git",
+                "reference": "d6c68f386c764674c59ee336d1dfca35aada5f90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://gitlab.com/api/v4/projects/hpierce1102%2FClassFinder/repository/archive.zip?sha=d6c68f386c764674c59ee336d1dfca35aada5f90",
+                "reference": "d6c68f386c764674c59ee336d1dfca35aada5f90",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "^1.6",
+                "phpunit/phpunit": "~9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "HaydenPierce\\ClassFinder\\": "src/",
+                    "HaydenPierce\\ClassFinder\\UnitTest\\": "test/unit"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Hayden Pierce",
+                    "email": "hayden@haydenpierce.com"
+                }
+            ],
+            "description": "A library that can provide of a list of classes in a given namespace",
+            "support": {
+                "issues": "https://gitlab.com/api/v4/projects/7670051/issues"
+            },
+            "time": "2021-01-05T20:50:49+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.0"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
+}

--- a/mu-plugins/10up-plugin/includes/classes/Module.php
+++ b/mu-plugins/10up-plugin/includes/classes/Module.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Module
+ *
+ * @package TenUpPlugin
+ */
+
+namespace TenUpPlugin;
+
+/**
+ * Module is any feature that conditionally activates based on the current context.
+ */
+abstract class Module {
+
+	/**
+	 * Checks whether the Module should run within the current context.
+	 *
+	 * @return bool
+	 */
+	abstract public function can_register();
+
+	/**
+	 * Connects the Module with WordPress using Hooks and/or Filters.
+	 *
+	 * @return void
+	 */
+	abstract public function register();
+
+}

--- a/mu-plugins/10up-plugin/includes/classes/Module.php
+++ b/mu-plugins/10up-plugin/includes/classes/Module.php
@@ -13,6 +13,17 @@ namespace TenUpPlugin;
 abstract class Module {
 
 	/**
+	 * Used to alter the order in which clases are initialized.
+	 *
+	 * Lower number will be initialized first.
+	 *
+	 * @note This has no correlation to the `init` priority. It's just a way to allow certain classes to be initialized before others.
+	 *
+	 * @var int The priority of the module.
+	 */
+	public $load_order = 10;
+
+	/**
 	 * Checks whether the Module should run within the current context.
 	 *
 	 * @return bool

--- a/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
+++ b/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
@@ -90,12 +90,30 @@ class ModuleInitialization {
 
 			// Initialize the class.
 			$instantiated_class = new $class();
-			// If the class can be registered, register it.
-			if ( $instantiated_class->can_register() ) {
-				// Call it's register method.
-				$instantiated_class->register();
-				// Store the class in the list of initialized classes.
-				$this->classes[ $slug ] = $instantiated_class;
+
+			// Assign the classes into the order they should be initialized.
+			$load_class_order[ intval( $instantiated_class->load_order ) ][] = [
+				'slug'  => $slug,
+				'class' => $instantiated_class,
+			];
+		}
+
+		// Sort the initialized classes by load order.
+		ksort( $load_class_order );
+
+		// Loop through the classes and initialize them.
+		foreach ( $load_class_order as $class_objects ) {
+			foreach ( $class_objects as $class_object ) {
+				$class = $class_object['class'];
+				$slug  = $class_object['slug'];
+
+				// If the class can be registered, register it.
+				if ( $class->can_register() ) {
+					// Call its register method.
+					$class->register();
+					// Store the class in the list of initialized classes.
+					$this->classes[ $slug ] = $class;
+				}
 			}
 		}
 	}

--- a/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
+++ b/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Auto-initialize all Module based clases in the plugin.
+ *
+ * @package TenUpPlugin
+ */
+
+namespace TenUpPlugin;
+
+use HaydenPierce\ClassFinder\ClassFinder;
+use ReflectionClass;
+
+/**
+ * ModuleInitialization class.
+ *
+ * @package TenUpPlugin
+ */
+class ModuleInitialization {
+
+	/**
+	 * The class instance.
+	 *
+	 * @var null|ModuleInitialization
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get the instance of the class.
+	 *
+	 * @return ModuleInitialization
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Override the constructor, we don't want to init it that way.
+	 */
+	private function __construct() {
+		// no-op. This class is a singleton.
+	}
+
+	/**
+	 * The list of initialized classes.
+	 *
+	 * @var array
+	 */
+	protected $classes = [];
+
+	/**
+	 * Get all the TenUpPlugin plugin classes.
+	 *
+	 * @return array
+	 */
+	protected function get_classes() {
+		return ClassFinder::getClassesInNamespace( 'TenUpPlugin', ClassFinder::RECURSIVE_MODE );
+	}
+
+	/**
+	 * Initialize all the TenUpPlugin plugin classes.
+	 *
+	 * @return void
+	 */
+	public function init_classes() {
+		foreach ( $this->get_classes() as $class ) {
+			// Create a slug for the class name.
+			$slug = $this->slugify_class_name( $class );
+
+			// If the class has already been initialized, skip it.
+			if ( isset( $this->classes[ $slug ] ) ) {
+				continue;
+			}
+
+			// Create a new reflection of the class.
+			$reflection_class = new ReflectionClass( $class );
+
+			// Using reflection, check if the class can be initialized.
+			// If not, skip.
+			if ( ! $reflection_class->isInstantiable() ) {
+				continue;
+			}
+
+			// Make sure the class is a subclass of Module, so we can initialize it.
+			if ( ! $reflection_class->isSubclassOf( '\TenUpPlugin\Module' ) ) {
+				continue;
+			}
+
+			// Initialize the class.
+			$instantiated_class = new $class();
+			// If the class can be registered, register it.
+			if ( $instantiated_class->can_register() ) {
+				// Call it's register method.
+				$instantiated_class->register();
+				// Store the class in the list of initialized classes.
+				$this->classes[ $slug ] = $instantiated_class;
+			}
+		}
+	}
+
+	/**
+	 * Slugify a class name.
+	 *
+	 * @param string $class_name The class name.
+	 *
+	 * @return string
+	 */
+	protected function slugify_class_name( $class_name ) {
+		return sanitize_title( str_replace( '\\', '-', $class_name ) );
+	}
+
+	/**
+	 * Get a class by its full class name, including namespace.
+	 *
+	 * @param string $class_name The class name & namespace.
+	 *
+	 * @return false|\TenUpPlugin\Module
+	 */
+	public function get_class( $class_name ) {
+		$class_name = $this->slugify_class_name( $class_name );
+
+		if ( isset( $this->classes[ $class_name ] ) ) {
+			return $this->classes[ $class_name ];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get all the initialized classes.
+	 *
+	 * @return array
+	 */
+	public function get_all_classes() {
+		return $this->classes;
+	}
+
+}

--- a/mu-plugins/10up-plugin/includes/core.php
+++ b/mu-plugins/10up-plugin/includes/core.php
@@ -55,6 +55,22 @@ function i18n() {
  */
 function init() {
 	do_action( 'tenup_plugin_before_init' );
+
+	// If the composer.json isn't found, trigger a warning.
+	if ( ! file_exists( TENUP_PLUGIN_PATH . 'composer.json' ) ) {
+		add_action(
+			'admin_notices',
+			function() {
+				$class = 'notice notice-error';
+				/* translators: %s: the path to the plugin */
+				$message = sprintf( __( 'The composer.json file was not found within %s. No classes will be loaded.', 'tenup-plugin' ), TENUP_PLUGIN_PATH );
+
+				printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
+			}
+		);
+		return;
+	}
+
 	ModuleInitialization::instance()->init_classes();
 	do_action( 'tenup_plugin_init' );
 }

--- a/mu-plugins/10up-plugin/includes/core.php
+++ b/mu-plugins/10up-plugin/includes/core.php
@@ -23,7 +23,7 @@ function setup() {
 	};
 
 	add_action( 'init', $n( 'i18n' ) );
-	add_action( 'init', $n( 'init' ), 8 );
+	add_action( 'init', $n( 'init' ), apply_filters( 'tenup_plugin_init_priority', 8 ) );
 	add_action( 'wp_enqueue_scripts', $n( 'scripts' ) );
 	add_action( 'wp_enqueue_scripts', $n( 'styles' ) );
 	add_action( 'admin_enqueue_scripts', $n( 'admin_scripts' ) );

--- a/mu-plugins/10up-plugin/includes/core.php
+++ b/mu-plugins/10up-plugin/includes/core.php
@@ -7,6 +7,7 @@
 
 namespace TenUpPlugin\Core;
 
+use TenUpPlugin\ModuleInitialization;
 use \WP_Error;
 use TenUpPlugin\Utility;
 
@@ -22,7 +23,7 @@ function setup() {
 	};
 
 	add_action( 'init', $n( 'i18n' ) );
-	add_action( 'init', $n( 'init' ) );
+	add_action( 'init', $n( 'init' ), 8 );
 	add_action( 'wp_enqueue_scripts', $n( 'scripts' ) );
 	add_action( 'wp_enqueue_scripts', $n( 'styles' ) );
 	add_action( 'admin_enqueue_scripts', $n( 'admin_scripts' ) );
@@ -53,6 +54,8 @@ function i18n() {
  * @return void
  */
 function init() {
+	do_action( 'tenup_plugin_before_init' );
+	ModuleInitialization::instance()->init_classes();
 	do_action( 'tenup_plugin_init' );
 }
 

--- a/mu-plugins/10up-plugin/includes/helpers/helpers.php
+++ b/mu-plugins/10up-plugin/includes/helpers/helpers.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin specific helpers.
+ *
+ * @package TenUpPlugin
+ */
+
+namespace TenUpPlugin;
+
+/**
+ * Get an initialized class by its full class name, including namespace.
+ *
+ * @param string $class_name The class name including the namespace.
+ *
+ * @return false|Module
+ */
+function get_module( $class_name ) {
+	return \TenUpPlugin\ModuleInitialization::instance()->get_class( $class_name );
+}

--- a/themes/10up-theme/composer.json
+++ b/themes/10up-theme/composer.json
@@ -8,7 +8,8 @@
     }
   ],
   "require": {
-    "php": ">=7.0"
+    "php": ">=7.0",
+    "haydenpierce/class-finder": "^0.4.3"
   },
   "autoload": {
     "psr-4": {

--- a/themes/10up-theme/composer.lock
+++ b/themes/10up-theme/composer.lock
@@ -1,11 +1,57 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adbeae4b8a041b45faf8cc21ddd60ade",
-    "packages": [],
+    "content-hash": "3df95c79aa556103ac2c289f8d00d5a7",
+    "packages": [
+        {
+            "name": "haydenpierce/class-finder",
+            "version": "0.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://gitlab.com/hpierce1102/ClassFinder.git",
+                "reference": "d6c68f386c764674c59ee336d1dfca35aada5f90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://gitlab.com/api/v4/projects/hpierce1102%2FClassFinder/repository/archive.zip?sha=d6c68f386c764674c59ee336d1dfca35aada5f90",
+                "reference": "d6c68f386c764674c59ee336d1dfca35aada5f90",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "^1.6",
+                "phpunit/phpunit": "~9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "HaydenPierce\\ClassFinder\\": "src/",
+                    "HaydenPierce\\ClassFinder\\UnitTest\\": "test/unit"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Hayden Pierce",
+                    "email": "hayden@haydenpierce.com"
+                }
+            ],
+            "description": "A library that can provide of a list of classes in a given namespace",
+            "support": {
+                "issues": "https://gitlab.com/api/v4/projects/7670051/issues"
+            },
+            "time": "2021-01-05T20:50:49+00:00"
+        }
+    ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
@@ -15,5 +61,6 @@
     "platform": {
         "php": ">=7.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
 }

--- a/themes/10up-theme/functions.php
+++ b/themes/10up-theme/functions.php
@@ -28,6 +28,7 @@ require_once TENUP_THEME_INC . 'overrides.php';
 require_once TENUP_THEME_INC . 'template-tags.php';
 require_once TENUP_THEME_INC . 'utility.php';
 require_once TENUP_THEME_INC . 'blocks.php';
+require_once TENUP_THEME_INC . 'helpers.php';
 
 // Run the setup functions.
 TenUpTheme\Core\setup();

--- a/themes/10up-theme/includes/classes/Module.php
+++ b/themes/10up-theme/includes/classes/Module.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Module
+ *
+ * @package TenUpTheme
+ */
+
+namespace TenUpTheme;
+
+/**
+ * Module is any feature that conditionally activates based on the current context.
+ */
+abstract class Module {
+
+	/**
+	 * Used to alter the order in which clases are initialized.
+	 *
+	 * Lower number will be initialized first.
+	 *
+	 * @note This has no correlation to the `init` priority. It's just a way to allow certain classes to be initialized before others.
+	 *
+	 * @var int The priority of the module.
+	 */
+	public $load_order = 10;
+
+	/**
+	 * Checks whether the Module should run within the current context.
+	 *
+	 * @return bool
+	 */
+	abstract public function can_register();
+
+	/**
+	 * Connects the Module with WordPress using Hooks and/or Filters.
+	 *
+	 * @return void
+	 */
+	abstract public function register();
+
+}

--- a/themes/10up-theme/includes/classes/ModuleInitialization.php
+++ b/themes/10up-theme/includes/classes/ModuleInitialization.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Auto-initialize all Module based clases in the theme.
+ *
+ * @package TenUpTheme
+ */
+
+namespace TenUpTheme;
+
+use HaydenPierce\ClassFinder\ClassFinder;
+use ReflectionClass;
+
+/**
+ * ModuleInitialization class.
+ *
+ * @package TenUpTheme
+ */
+class ModuleInitialization {
+
+	/**
+	 * The class instance.
+	 *
+	 * @var null|ModuleInitialization
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get the instance of the class.
+	 *
+	 * @return ModuleInitialization
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Override the constructor, we don't want to init it that way.
+	 */
+	private function __construct() {
+		// no-op. This class is a singleton.
+	}
+
+	/**
+	 * The list of initialized classes.
+	 *
+	 * @var array
+	 */
+	protected $classes = [];
+
+	/**
+	 * Get all the TenUpTheme plugin classes.
+	 *
+	 * @return array
+	 */
+	protected function get_classes() {
+		return ClassFinder::getClassesInNamespace( 'TenUpTheme', ClassFinder::RECURSIVE_MODE );
+	}
+
+	/**
+	 * Initialize all the TenUpTheme plugin classes.
+	 *
+	 * @return void
+	 */
+	public function init_classes() {
+		$load_class_order = [];
+
+		foreach ( $this->get_classes() as $class ) {
+			// Create a slug for the class name.
+			$slug = $this->slugify_class_name( $class );
+
+			// If the class has already been initialized, skip it.
+			if ( isset( $this->classes[ $slug ] ) ) {
+				continue;
+			}
+
+			// Create a new reflection of the class.
+			$reflection_class = new ReflectionClass( $class );
+
+			// Using reflection, check if the class can be initialized.
+			// If not, skip.
+			if ( ! $reflection_class->isInstantiable() ) {
+				continue;
+			}
+
+			// Make sure the class is a subclass of Module, so we can initialize it.
+			if ( ! $reflection_class->isSubclassOf( '\TenUpTheme\Module' ) ) {
+				continue;
+			}
+
+			// Initialize the class.
+			$instantiated_class = new $class();
+
+			// Assign the classes into the order they should be initialized.
+			$load_class_order[ intval( $instantiated_class->load_order ) ][] = [
+				'slug'  => $slug,
+				'class' => $instantiated_class,
+			];
+		}
+
+		// Sort the initialized classes by load order.
+		ksort( $load_class_order );
+
+		// Loop through the classes and initialize them.
+		foreach ( $load_class_order as $class_objects ) {
+			foreach ( $class_objects as $class_object ) {
+				$class = $class_object['class'];
+				$slug  = $class_object['slug'];
+
+				// If the class can be registered, register it.
+				if ( $class->can_register() ) {
+					// Call its register method.
+					$class->register();
+					// Store the class in the list of initialized classes.
+					$this->classes[ $slug ] = $class;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Slugify a class name.
+	 *
+	 * @param string $class_name The class name.
+	 *
+	 * @return string
+	 */
+	protected function slugify_class_name( $class_name ) {
+		return sanitize_title( str_replace( '\\', '-', $class_name ) );
+	}
+
+	/**
+	 * Get a class by its full class name, including namespace.
+	 *
+	 * @param string $class_name The class name & namespace.
+	 *
+	 * @return false|\TenUpTheme\Module
+	 */
+	public function get_class( $class_name ) {
+		$class_name = $this->slugify_class_name( $class_name );
+
+		if ( isset( $this->classes[ $class_name ] ) ) {
+			return $this->classes[ $class_name ];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get all the initialized classes.
+	 *
+	 * @return array
+	 */
+	public function get_all_classes() {
+		return $this->classes;
+	}
+
+}

--- a/themes/10up-theme/includes/core.php
+++ b/themes/10up-theme/includes/core.php
@@ -7,6 +7,7 @@
 
 namespace TenUpTheme\Core;
 
+use TenUpTheme\ModuleInitialization;
 use TenUpTheme\Utility;
 
 /**
@@ -41,6 +42,22 @@ function setup() {
  */
 function init() {
 	do_action( 'tenup_theme_before_init' );
+
+	// If the composer.json isn't found, trigger a warning.
+	if ( ! file_exists( TENUP_THEME_PATH . 'composer.json' ) ) {
+		add_action(
+			'admin_notices',
+			function() {
+				$class = 'notice notice-error';
+				/* translators: %s: the path to the plugin */
+				$message = sprintf( __( 'The composer.json file was not found within %s. No classes will be loaded.', 'tenup-theme' ), TENUP_THEME_PATH );
+
+				printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
+			}
+		);
+		return;
+	}
+
 	ModuleInitialization::instance()->init_classes();
 	do_action( 'tenup_theme_init' );
 }

--- a/themes/10up-theme/includes/core.php
+++ b/themes/10up-theme/includes/core.php
@@ -19,6 +19,7 @@ function setup() {
 		return __NAMESPACE__ . "\\$function";
 	};
 
+	add_action( 'init', $n( 'init' ), apply_filters( 'tenup_theme_init_priority', 8 ) );
 	add_action( 'after_setup_theme', $n( 'i18n' ) );
 	add_action( 'after_setup_theme', $n( 'theme_setup' ) );
 	add_action( 'wp_enqueue_scripts', $n( 'scripts' ) );
@@ -31,6 +32,17 @@ function setup() {
 	add_action( 'wp_head', $n( 'embed_ct_css' ), 0 );
 
 	add_filter( 'script_loader_tag', $n( 'script_loader_tag' ), 10, 2 );
+}
+
+/**
+ * Initializes the theme classes and fires an action plugins can hook into.
+ *
+ * @return void
+ */
+function init() {
+	do_action( 'tenup_theme_before_init' );
+	ModuleInitialization::instance()->init_classes();
+	do_action( 'tenup_theme_init' );
 }
 
 /**

--- a/themes/10up-theme/includes/helpers.php
+++ b/themes/10up-theme/includes/helpers.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Theme specific helpers.
+ *
+ * @package TenUpTheme
+ */
+
+namespace TenUpTheme;
+
+/**
+ * Get an initialized class by its full class name, including namespace.
+ *
+ * @param string $class_name The class name including the namespace.
+ *
+ * @return false|Module
+ */
+function get_module( $class_name ) {
+	return \TenUpTheme\ModuleInitialization::instance()->get_class( $class_name );
+}


### PR DESCRIPTION
Currently there is very little PHP scaffolding in the repo, especially in the MU-Plugin. This means that to set up, engineers usually end up copy/pasting the scaffold from other projects. This PR proposes a starting point for a less obstructive PHP scaffold, where PHP classes are automatically registered based on conditionals.

### Description of the Change

This PR does the following:

* Adds a new abstract `Module` class that defines `can_register()` and `register()` methods.
* Utilizes the [haydenpierce/class-finder](https://packagist.org/packages/haydenpierce/class-finder) package to find all classes within a namespace (currently `TenUpPlugin`)
* Of all the found classes, find those that extend the `Module` class.
* Of those classes, find those where the `can_register()` method returns `true`.
* Calls the `register()` method on all those remaining.

There is some documentation available within the `docs` directory, see [here](https://github.com/10up/wp-scaffold/blob/feature/auto-initialize-modules/docs/registering-classes.md).

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
This is related to #4

### How to test the Change
Clone the repo into a WordPress install and try registering a class using the new method.

### Changelog Entry

> Added - Auto-registration of PHP classes in the MU-plugin

### Credits
Props @darylldoyle 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
