### PR TITLE
Fix: get_colors() does not accept modern alpha channel syntax

### DIFF
--- a/themes/10up-theme/includes/utility.php
+++ b/themes/10up-theme/includes/utility.php
@@ -48,8 +48,10 @@ function get_colors( $path ) {
 	if ( file_exists( $dir . $path ) ) {
 		$css_vars = file_get_contents( $dir . $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions
 		// HEX(A) | RGB(A) | HSL(A) - rgba & hsla alpha as decimal or percentage
-		// https://regex101.com/r/FEtzDu/5
-		preg_match_all( '(#(?:[\da-f]{3}){1}\b|#(?:[\da-f]{2}){3,4}\b|(rgb|hsl)a?\((\s*-?\d+%?\s*,){2}(\s*-?\d+%?\s*)\)|(rgb|hsl)a?\((\s*-?\d+%?\s*,){3}\s*(0|(0?\.\d+)|1|(\s*\d{1,3}%\s*))\))', $css_vars, $matches );
+		// https://regex101.com/r/l7AZ8R/
+		// this is a loose match and will accept almost anything within () for rgb(a) & hsl(a)
+		// a more optinionated solution is WIP here if you can improve on it https://regex101.com/r/FEtzDu/
+		preg_match_all( '(#(?:[\da-f]{3}){1}\b|#(?:[\da-f]{2}){3,4}\b|(rgb|hsl)a?\((\s|\d|[a-zA-Z]+|,|-|%|\.|\/)+\))', $css_vars, $matches );
 
 		return $matches[0];
 	}

--- a/themes/10up-theme/includes/utility.php
+++ b/themes/10up-theme/includes/utility.php
@@ -47,9 +47,10 @@ function get_colors( $path ) {
 
 	if ( file_exists( $dir . $path ) ) {
 		$css_vars = file_get_contents( $dir . $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions
-		preg_match_all( ' /#([a-f]|[A-F]|[0-9]){3}(([a-f]|[A-F]|[0-9]){3})?\b/', $css_vars, $matches );
-		// HEX | RGB(A) | HSL(A)
-		preg_match_all( '(#([\da-f]{3}){1,2}|(rgb|hsl)a\((\d{1,3}%?,\s?){3}(1|0?\.\d+)\)|(rgb|hsl)\(\d{1,3}%?(,\s?\d{1,3}%?){2}\))', $css_vars, $matches );
+		// HEX | RGB(A) | HSL(A) - alpha as decimal or percentage
+		// https://regex101.com/r/FEtzDu/1
+		preg_match_all( '(#(?:[\da-f]{3}){1,2}$|^#(?:[\da-f]{4}){1,2}$|(rgb|hsl)a?\((\s*-?\d+%?\s*,){2}(\s*-?\d+%?\s*)\)|(rgb|hsl)a?\((\s*-?\d+%?\s*,){3}\s*(0|(0?\.\d+)|1|(\s*\d{1,3}%\s*))\))', $css_vars, $matches );
+
 		return $matches[0];
 	}
 

--- a/themes/10up-theme/includes/utility.php
+++ b/themes/10up-theme/includes/utility.php
@@ -47,9 +47,9 @@ function get_colors( $path ) {
 
 	if ( file_exists( $dir . $path ) ) {
 		$css_vars = file_get_contents( $dir . $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions
-		// HEX | RGB(A) | HSL(A) - alpha as decimal or percentage
-		// https://regex101.com/r/FEtzDu/1
-		preg_match_all( '(#(?:[\da-f]{3}){1,2}$|^#(?:[\da-f]{4}){1,2}$|(rgb|hsl)a?\((\s*-?\d+%?\s*,){2}(\s*-?\d+%?\s*)\)|(rgb|hsl)a?\((\s*-?\d+%?\s*,){3}\s*(0|(0?\.\d+)|1|(\s*\d{1,3}%\s*))\))', $css_vars, $matches );
+		// HEX(A) | RGB(A) | HSL(A) - rgba & hsla alpha as decimal or percentage
+		// https://regex101.com/r/FEtzDu/5
+		preg_match_all( '(#(?:[\da-f]{3}){1}\b|#(?:[\da-f]{2}){3,4}\b|(rgb|hsl)a?\((\s*-?\d+%?\s*,){2}(\s*-?\d+%?\s*)\)|(rgb|hsl)a?\((\s*-?\d+%?\s*,){3}\s*(0|(0?\.\d+)|1|(\s*\d{1,3}%\s*))\))', $css_vars, $matches );
 
 		return $matches[0];
 	}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

The PHP function get_colors() used by the styleguide template does not match modern color syntax as required by linter updates. This updates get_colors() to cover both decimal and percentage alpha channel values where used for RGBA and HSLA colour formats.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes [#163](https://github.com/10up/wp-scaffold/issues/163)

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - [#163](https://github.com/10up/wp-scaffold/issues/163)


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @colinswinney for spotting the issue


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [n/a] I have updated the documentation accordingly.
- [n/a] I have added tests to cover my change.
- [n/a] All new and existing tests pass.
