### PR TITLE
Move to block collection from block category.

### DIFF
--- a/themes/10up-theme/includes/block-collection.js
+++ b/themes/10up-theme/includes/block-collection.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockCollection } from '@wordpress/blocks';
+
+/**
+ * Register block collection.
+ * See https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/#registerblockcollection
+ */
+registerBlockCollection('tenup', {
+	title: __('Custom Blocks', 'tenup-theme'),
+});

--- a/themes/10up-theme/includes/blocks.php
+++ b/themes/10up-theme/includes/blocks.php
@@ -21,8 +21,6 @@ function setup() {
 
 	add_action( 'enqueue_block_editor_assets', $n( 'blocks_editor_styles' ) );
 
-	add_filter( 'block_categories_all', $n( 'blocks_categories' ), 10, 2 );
-
 	add_action( 'init', $n( 'register_theme_blocks' ) );
 
 	add_action( 'init', $n( 'register_block_pattern_categories' ) );
@@ -129,25 +127,6 @@ function blocks_editor_styles() {
 		);
 	}
 
-}
-
-/**
- * Filters the registered block categories.
- *
- * @param array $categories Registered categories.
- *
- * @return array Filtered categories.
- */
-function blocks_categories( $categories ) {
-	return array_merge(
-		$categories,
-		array(
-			array(
-				'slug'  => 'tenup-theme-blocks',
-				'title' => __( 'Custom Blocks', 'tenup-theme' ),
-			),
-		)
-	);
 }
 
 /**

--- a/themes/10up-theme/includes/blocks/example-block/block.json
+++ b/themes/10up-theme/includes/blocks/example-block/block.json
@@ -6,7 +6,7 @@
   "textdomain": "tenup-theme",
   "name": "tenup/example",
   "icon": "feedback",
-  "category": "tenup-theme-blocks",
+  "category": "formatting",
   "attributes":{
     "title": {
       "type" : "string"

--- a/themes/10up-theme/includes/core-block-overrides.js
+++ b/themes/10up-theme/includes/core-block-overrides.js
@@ -2,6 +2,7 @@
  * Entry point for all core block overrides
  */
 
+import './block-collection';
 // import './block-filters';
 // import './block-styles';
 // import './block-variations';


### PR DESCRIPTION
### Description of the Change
As suggested in #76, This PR contains changes for switching to Block collection from block category. Block collection allows blocks to have a semantic category and still shows them in a branded fashion in the inserter in order to provide a good editorial experience.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #76 

### How to test the Change
1. Set up a repo by checkout to this PR.
2. Add/Edit page in the Gutenberg editor.
3. Open block insterter. 
4. Verify that the `Example Block` is visible under the `Text`(formatting) category and `Custom Blocks` collection.

### Changelog Entry
> Changed - Moved to "Custom Blocks" block collection from the "Custom Blocks" block category

### Credits
Props @iamdharmesh @fabiankaegy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
