### PR TITLE
Initialize the array load_cass_order

### DIFF
--- a/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
+++ b/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
@@ -65,6 +65,7 @@ class ModuleInitialization {
 	 * @return void
 	 */
 	public function init_classes() {
+		$load_class_order = [];
 		foreach ( $this->get_classes() as $class ) {
 			// Create a slug for the class name.
 			$slug = $this->slugify_class_name( $class );


### PR DESCRIPTION
Removes error thrown if `load_class_order` is null

### Description of the Change
Fixes this error when load_class_order returns null:

```
Fatal error: Uncaught TypeError: ksort(): Argument #1 ($array) must be of type array, null given in /var/www/html/wp-content/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php:102 Stack trace: #0 /var/www/html/wp-content/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php(102): ksort() #1 /var/www/html/wp-content/mu-plugins/10up-plugin/includes/core.php(74): TenUpPlugin\ModuleInitialization->init_classes() #2 /var/www/html/wp-includes/class-wp-hook.php(308): TenUpPlugin\Core\init() #3 /var/www/html/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters() #4 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action() #5 /var/www/html/wp-settings.php(617): do_action() #6 /var/www/html/wp-config.php(116): require_once('...') #7 /var/www/html/wp-load.php(50): require_once('...') #8 /var/www/html/wp-admin/admin.php(34): require_once('...') #9 /var/www/html/wp-admin/themes.php(10): require_once('...') #10 {main} thrown in /var/www/html/wp-content/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php on line 102
```


### How to test the Change
After copying mu-plugin into a new build, run `composer install` to install the plugin 
Build the site and view on the front-end

### Changelog Entry
> Fixed - Bug fix

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @johnwatkins0 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
