### PR TITLE
auto versioning for editor styles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
   "scripts": {
     "lint": "phpcs .",
     "lint-fix": "phpcbf ."
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/themes/10up-theme/includes/blocks.php
+++ b/themes/10up-theme/includes/blocks.php
@@ -61,8 +61,21 @@ function register_theme_blocks() {
 		foreach ( $block_json_files as $filename ) {
 
 			$block_folder = dirname( $filename );
+			$block_name   = basename( $block_folder );
 
 			$block_options = [];
+
+			/**
+			 * Register block editor style with automated versioning
+			 * It can be used in block.json as "editorStyle" property using the style handler which is the name of the block folder
+			 * If the style isn't registered it'll be enqueued using the WordPress Core version
+			 * causing a long term caching
+			 */
+			$editor_style_file_path = $block_folder . '/editor.css';
+			if ( file_exists( $editor_style_file_path ) ) {
+				$style_url = TENUP_THEME_TEMPLATE_URL . '/dist/css/' . $block_name . '.css';
+				wp_register_style( $block_name, $style_url, array(), filemtime( $editor_style_file_path ) );
+			}
 
 			$markup_file_path = $block_folder . '/markup.php';
 			if ( file_exists( $markup_file_path ) ) {

--- a/themes/10up-theme/includes/blocks.php
+++ b/themes/10up-theme/includes/blocks.php
@@ -73,7 +73,7 @@ function register_theme_blocks() {
 			 */
 			$editor_style_file_path = $block_folder . '/editor.css';
 			if ( file_exists( $editor_style_file_path ) ) {
-				$style_url = TENUP_THEME_TEMPLATE_URL . '/dist/css/' . $block_name . '.css';
+				$style_url = TENUP_THEME_TEMPLATE_URL . '/dist/blocks/' . $block_name . '/index.css';
 				wp_register_style( $block_name, $style_url, array(), filemtime( $editor_style_file_path ) );
 			}
 

--- a/themes/10up-theme/includes/blocks/example-block/block.json
+++ b/themes/10up-theme/includes/blocks/example-block/block.json
@@ -20,5 +20,6 @@
   "supports": {
     "html": false
   },
-  "editorScript": "file:./index.js"
+  "editorScript": "file:./index.js",
+  "editorStyle": "example-block"
 }

--- a/themes/10up-theme/includes/blocks/example-block/edit.js
+++ b/themes/10up-theme/includes/blocks/example-block/edit.js
@@ -4,6 +4,9 @@
 import { __ } from '@wordpress/i18n';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 
+// Importing the block's editor styles via JS will enable hot reloading for css
+import './editor.css';
+
 /**
  * Edit component.
  * See https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-edit-save/#edit

--- a/themes/10up-theme/includes/blocks/example-block/editor.css
+++ b/themes/10up-theme/includes/blocks/example-block/editor.css
@@ -1,0 +1,3 @@
+.wp-block-example-block__title {
+	font-style: italic;
+}


### PR DESCRIPTION
### Description of the Change

We found some instances where we included editorStyles but these are enqueued using the WordPress Core version by default and this can be problematic each time we update those styles since the file are being long-term cached by the environment. I made this fix to ensure we're automatically registering the styles with a dynamic version and then just passing the style handler to the block.json.

### How to test the Change
Run `npm run install && npm run build` and then test the theme in a WordPress install.
check the network panel once you enter to the block editor and look for the CSS file included in the editor as part of the example-block. The file should have the `ver` parameter something like `?ver=1672948490` instead of `?ver=6.1.1`

### Changelog Entry
> Added - Auto versioning for editor styles inside blocks

### Credits
Props @hugosolar 


### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
