### PR TITLE
Repair typos in docs and remove extraneous echo

### DIFF
--- a/themes/10up-theme/functions.php
+++ b/themes/10up-theme/functions.php
@@ -43,7 +43,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 if ( ! function_exists( 'wp_body_open' ) ) {
 
 	/**
-	 * Shim for the the new wp_body_open() function that was added in 5.2
+	 * Shim for the new wp_body_open() function that was added in 5.2
 	 */
 	function wp_body_open() {
 		do_action( 'wp_body_open' );

--- a/themes/10up-theme/header.php
+++ b/themes/10up-theme/header.php
@@ -16,7 +16,7 @@
 	<body <?php body_class(); ?>>
 		<?php wp_body_open(); ?>
 
-		<a href="#main" class="skip-to-content-link visually-hidden-focusable"><?php echo esc_html_e( 'Skip to main content', 'tenup-theme' ); ?></a>
+		<a href="#main" class="skip-to-content-link visually-hidden-focusable"><?php esc_html_e( 'Skip to main content', 'tenup-theme' ); ?></a>
 
 		<main id="main" role="main" tabindex="-1">
 

--- a/themes/10up-theme/includes/classes/Module.php
+++ b/themes/10up-theme/includes/classes/Module.php
@@ -13,7 +13,7 @@ namespace TenUpTheme;
 abstract class Module {
 
 	/**
-	 * Used to alter the order in which clases are initialized.
+	 * Used to alter the order in which classes are initialized.
 	 *
 	 * Lower number will be initialized first.
 	 *

--- a/themes/10up-theme/includes/classes/ModuleInitialization.php
+++ b/themes/10up-theme/includes/classes/ModuleInitialization.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Auto-initialize all Module based clases in the theme.
+ * Auto-initialize all Module based classes in the theme.
  *
  * @package TenUpTheme
  */


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR repairs three typos and removes an extraneous echo statement.
- "clases" to "classes"
- "the the" to "the"
- "echo esc_html_e" to "esc_html_e"

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes # N/A

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Typo changes are in docBlocks, echo removal is in the "Skip to main content" link text

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Repair typos in docBlocks; remove extraneous echo statement

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...
@dylanjameswagner

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
