### PR TITLE
Fix issue with static methods in class autoloader

### DIFF
--- a/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
+++ b/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
@@ -56,7 +56,9 @@ class ModuleInitialization {
 	 * @return array
 	 */
 	protected function get_classes() {
-		return ClassFinder::getClassesInNamespace( 'TenUpPlugin', ClassFinder::RECURSIVE_MODE );
+		$class_finder = new ClassFinder();
+		$class_finder::setAppRoot( TENUP_PLUGIN_PATH );
+		return $class_finder::getClassesInNamespace( 'TenUpPlugin', ClassFinder::RECURSIVE_MODE );
 	}
 
 	/**

--- a/themes/10up-theme/includes/classes/ModuleInitialization.php
+++ b/themes/10up-theme/includes/classes/ModuleInitialization.php
@@ -56,7 +56,9 @@ class ModuleInitialization {
 	 * @return array
 	 */
 	protected function get_classes() {
-		return ClassFinder::getClassesInNamespace( 'TenUpTheme', ClassFinder::RECURSIVE_MODE );
+		$class_finder = new ClassFinder();
+		$class_finder::setAppRoot( TENUP_THEME_PATH );
+		return $class_finder::getClassesInNamespace( 'TenUpTheme', ClassFinder::RECURSIVE_MODE );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
In #158 we added a way to auto-initialise and load classes in the MU plugin and theme.
Because the classfinder uses static methods, it only works on a single application root.

To get around this, we need to manually set the application root before we look for classes in a namespace, so that it can find the right composer.json file

This has been tested on a client project that's using this version of the scaffold.

### How to test the Change
- Add a class to the MU plugin and another to the theme. 
- Make sure that both are registered.

### Changelog Entry
* Fixed - Issue with class loading conflict.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
