### PR TITLE
Fix incorrect formatting in all editorconfig files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
-[*.txt]
+[{*.txt,wp-config-sample.php}]
 end_of_line = crlf

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
-[*.txt,wp-config-sample.php]
+[*.txt]
 end_of_line = crlf

--- a/mu-plugins/10up-plugin/.editorconfig
+++ b/mu-plugins/10up-plugin/.editorconfig
@@ -11,5 +11,5 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
-[*.txt]
+[{*.txt,wp-config-sample.php}]
 end_of_line = crlf

--- a/mu-plugins/10up-plugin/.editorconfig
+++ b/mu-plugins/10up-plugin/.editorconfig
@@ -11,5 +11,5 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
-[*.txt,wp-config-sample.php]
+[*.txt]
 end_of_line = crlf

--- a/themes/10up-theme/.editorconfig
+++ b/themes/10up-theme/.editorconfig
@@ -11,5 +11,5 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
-[*.txt]
+[{*.txt,wp-config-sample.php}]
 end_of_line = crlf

--- a/themes/10up-theme/.editorconfig
+++ b/themes/10up-theme/.editorconfig
@@ -11,5 +11,5 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
-[*.txt,wp-config-sample.php]
+[*.txt]
 end_of_line = crlf


### PR DESCRIPTION
### Description of the Change

Fixes formatting error for `crlf` line in all repository .editorconfig files. This may have been originally copied over from [wordpress-deveop](https://github.com/WordPress/wordpress-develop/blob/master/.editorconfig) (see link for correct usage). I initially thought of just removing `wp-config-sample.php` from the files since the purpose isn't 100% clear but instead updated the PR to the correct format.

![image](https://user-images.githubusercontent.com/303829/223889014-c2fbbe51-2764-4236-9ee9-15de0feeb8ba.png)

* Multiple items need to be wrapped with curly braces. Docs on [Glob Expressions](https://spec.editorconfig.org/#glob-expressions).

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Fixed .editorconfig format error

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @bjorn2404 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.