### PR TITLE
Fix mu-plugin entry file referencing wrong variable

### DIFF
--- a/mu-plugins/10up-plugin/plugin.php
+++ b/mu-plugins/10up-plugin/plugin.php
@@ -5,6 +5,8 @@ define( 'TENUP_PLUGIN_VERSION', '0.1.0' );
 define( 'TENUP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'TENUP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'TENUP_PLUGIN_INC', TENUP_PLUGIN_PATH . 'includes/' );
+define( 'TENUP_PLUGIN_DIST_URL', TENUP_PLUGIN_URL . 'dist/' );
+define( 'TENUP_PLUGIN_DIST_PATH', TENUP_PLUGIN_PATH . 'dist/' );
 
 $is_local_env = in_array( wp_get_environment_type(), [ 'local', 'development' ], true );
 $is_local_url = strpos( home_url(), '.test' ) || strpos( home_url(), '.local' );
@@ -12,7 +14,7 @@ $is_local     = $is_local_env || $is_local_url;
 
 if ( $is_local && file_exists( __DIR__ . '/dist/fast-refresh.php' ) ) {
 	require_once __DIR__ . '/dist/fast-refresh.php';
-	TenUpToolkit\set_dist_url_path( basename( __DIR__ ), TENUP_THEME_DIST_URL, TENUP_THEME_DIST_PATH );
+	TenUpToolkit\set_dist_url_path( basename( __DIR__ ), TENUP_PLUGIN_DIST_URL, TENUP_PLUGIN_DIST_PATH );
 }
 
 // Require Composer autoloader if it exists.


### PR DESCRIPTION
### Description of the Change
The mu-plugin main file was referencing a PHP constant defined in the theme, which gets loaded after the mu-plugin causing the site to break.

### How to test the Change
Install WP scaffold and setup composer/npm. The site should just work.

### Changelog Entry
> Fixed - mu-plugin breaking the site


### Credits
Props @theskinnyghost 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
