### PR TITLE
rename core block overrides JS file to block editor script for greater clarity

### DIFF
--- a/themes/10up-theme/includes/block-editor-script.js
+++ b/themes/10up-theme/includes/block-editor-script.js
@@ -1,5 +1,5 @@
 /**
- * Entry point for all core block overrides
+ * Entry point for all block editor specific scripts.
  */
 
 import './block-collection';

--- a/themes/10up-theme/includes/core.php
+++ b/themes/10up-theme/includes/core.php
@@ -189,7 +189,7 @@ function enqueue_block_editor_scripts() {
 	wp_enqueue_script(
 		'block-editor-script',
 		TENUP_THEME_DIST_URL . 'js/block-editor-script.js',
-		UTility\get_asset_info( 'block-editor-script', 'dependencies' ),
+		Utility\get_asset_info( 'block-editor-script', 'dependencies' ),
 		Utility\get_asset_info( 'block-editor-script', 'version' ),
 		true
 	);

--- a/themes/10up-theme/includes/core.php
+++ b/themes/10up-theme/includes/core.php
@@ -26,7 +26,7 @@ function setup() {
 	add_action( 'wp_enqueue_scripts', $n( 'scripts' ) );
 	add_action( 'admin_enqueue_scripts', $n( 'admin_styles' ) );
 	add_action( 'admin_enqueue_scripts', $n( 'admin_scripts' ) );
-	add_action( 'enqueue_block_editor_assets', $n( 'core_block_overrides' ) );
+	add_action( 'enqueue_block_editor_assets', $n( 'enqueue_block_editor_scripts' ) );
 	add_action( 'wp_enqueue_scripts', $n( 'styles' ) );
 	add_action( 'wp_head', $n( 'js_detection' ), 0 );
 	add_action( 'wp_head', $n( 'embed_ct_css' ), 0 );
@@ -185,18 +185,14 @@ function admin_scripts() {
  *
  * @return void
  */
-function core_block_overrides() {
-	$overrides = TENUP_THEME_DIST_PATH . 'js/core-block-overrides.asset.php';
-	if ( file_exists( $overrides ) ) {
-		$dep = require_once $overrides;
-		wp_enqueue_script(
-			'core-block-overrides',
-			TENUP_THEME_DIST_URL . 'js/core-block-overrides.js',
-			$dep['dependencies'],
-			$dep['version'],
-			true
-		);
-	}
+function enqueue_block_editor_scripts() {
+	wp_enqueue_script(
+		'block-editor-script',
+		TENUP_THEME_DIST_URL . 'js/block-editor-script.js',
+		UTility\get_asset_info( 'block-editor-script', 'dependencies' ),
+		Utility\get_asset_info( 'block-editor-script', 'version' ),
+		true
+	);
 }
 
 /**

--- a/themes/10up-theme/package.json
+++ b/themes/10up-theme/package.json
@@ -28,7 +28,7 @@
       "frontend": "./assets/js/frontend/frontend.js",
       "shared": "./assets/js/shared/shared.js",
       "styleguide": "./assets/js/styleguide/styleguide.js",
-      "core-block-overrides": "./includes/core-block-overrides.js"
+      "block-editor-script": "./includes/block-editor-script.js"
     }
   }
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

The `core-block-overrides` file is named incorrectly. In reality this file is used for all kinds of things in the block editor. Because of the name though, folks are often confused as to where other types of customization such as new meta fields etc should be placed. 


