### PR TITLE
fix deprecated variable format

### DIFF
--- a/mu-plugins/10up-plugin/includes/core.php
+++ b/mu-plugins/10up-plugin/includes/core.php
@@ -121,7 +121,7 @@ function script_url( $script, $context ) {
 		return new WP_Error( 'invalid_enqueue_context', 'Invalid $context specified in TenUpPlugin script loader.' );
 	}
 
-	return TENUP_PLUGIN_URL . "dist/js/${script}.js";
+	return TENUP_PLUGIN_URL . "dist/js/{$script}.js";
 
 }
 
@@ -139,7 +139,7 @@ function style_url( $stylesheet, $context ) {
 		return new WP_Error( 'invalid_enqueue_context', 'Invalid $context specified in TenUpPlugin stylesheet loader.' );
 	}
 
-	return TENUP_PLUGIN_URL . "dist/css/${stylesheet}.css";
+	return TENUP_PLUGIN_URL . "dist/css/{$stylesheet}.css";
 
 }
 


### PR DESCRIPTION
In PHP 8.2, the alternative syntax of placing the dollar sign outside the curly braces is deprecated.

See: 
* https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation
* https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

### Description of the Change

Addresses deprecated `${var}` format in PHP 8.2 


### How to test the Change

Enable the debug log and see the deprecation messages.

### Changelog Entry

> Fixed - deprecated variable format


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
