### PR TITLE
Feature/php post type and taxonomy scaffold

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,11 @@
         "type:wordpress-plugin"
       ]
     }
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "composer/installers": true
+    }
   }
 }

--- a/docs/creating-post-types-and-taxonomies.md
+++ b/docs/creating-post-types-and-taxonomies.md
@@ -1,0 +1,271 @@
+# Creating Post Types and Taxonomies in the MU-Plugin
+
+The MU plugin contains abstract classses that can be extended to easily register new post types and taxonomies. This document will explain how to use these classes to create new post types and taxonomies.
+
+If you want to jump right in, take a look at the `TenUpPlugin\PostTypes\Demo::class` and `TenUpPlugin\Taxonomies\Demo::class` classes.
+
+
+## Post Types
+
+To create a new post type, you will need to create a new class that extends the `TenUpPlugin\PostTypes\AbstractPostType` class. This class will contain the configuration for the new post type.
+
+Once you've extended the class (or copied the `Demo` class), you will need to define the following methods:
+
+- `get_name()` - This should return the name of the post type as it will be used within the WordPress database.
+- `get_singular_label()` - This should return the singular label for the post type.
+- `get_plural_label()` - This should return the plural label for the post type.
+- `get_menu_icon()` - This should return the dashicon to use for the post type in the WordPress admin menu, it can also return a base64 encoded SVG or the string `'none'`.
+- `can_register()` - Whether the post type should be actively registered or not. See [Registering Classes](./registering-classes.md).
+
+Once those are defined, ensure that `can_register()` is returning `true` and you should be able to see your post type within the admin.
+
+### Heirarchical Post Types
+
+Should you need to create a heirarchical post type, you can override the `is_hierarchical()` method and return `true`.
+
+```php
+/**
+ * Is the post type hierarchical?
+ *
+ * @return bool
+ */
+public function is_hierarchical() {
+	return true;
+}
+```
+
+### Changing the Post Supports
+
+There are a few options that can exist within [post supports](https://developer.wordpress.org/reference/functions/register_post_type/#parameters:~:text=handling.%0ADefault%20false.-,supports,-array), the scaffold aims to set sensible defaults but sometimes they will need changing. There are two ways to do this:
+
+a. Override the `get_editor_supports()` method and return an array of the supports you want to enable.
+
+```php
+/**
+ * Default post type supported feature names.
+ *
+ * @return array
+ */
+public function get_editor_supports() {
+	$supports = [
+		'title',
+		'editor',
+		'thumbnail',
+		'custom-fields',
+	];
+
+	return $supports;
+}
+```
+b. Merge your additional supports into the base version
+
+```php
+/**
+ * Default post type supported feature names.
+ *
+ * @return array
+ */
+public function get_editor_supports() {
+	$supports   = parent::get_editor_supports();
+	$supports[] = 'custom-fields';
+
+	return $supports;
+}
+```
+
+### Changing Post Type Options
+
+Much like with the Supports, the scaffold aims to set sensible defaults for the post type options. Should you want to change these, you can handle it in much the same way:
+
+a. Override the `get_options()` method and return an array of the options you want to enable.
+
+```php
+/**
+ * Default post type supported feature names.
+ *
+ * @return array
+ */
+public function get_options() {
+	$options = [
+			'labels'            => $this->get_labels(),
+			'public'            => false,
+			'has_archive'       => false,
+			'show_ui'           => true,
+			'show_in_menu'      => true,
+			'show_in_nav_menus' => false,
+			'show_in_rest'      => true,
+			'supports'          => $this->get_editor_supports(),
+			'menu_icon'         => $this->get_menu_icon(),
+			'menu_position'     => $this->get_menu_position(),
+			'hierarchical'      => $this->is_hierarchical(),
+		];
+
+	return $options;
+}
+```
+b. Merge your additional options into the base version
+
+```php
+/**
+ * Default post type supported feature names.
+ *
+ * @return array
+ */
+public function get_options() {
+	$options                = parent::get_options();
+	$options['public']      = false;
+	$options['has_archive'] = false;
+
+	return $options;
+}
+```
+
+### Adding Taxonomies to a Post Type
+
+To add a taxonomy to a post type, you'll need to override the `get_supported_taxonomies()` method on the post type class and return an array of taxonomies you'd like to support.
+
+E.G.
+
+```php
+/**
+ * Returns the default supported taxonomies. The subclass should declare the
+ * Taxonomies that it supports here if required.
+ *
+ * @return array
+ */
+public function get_supported_taxonomies() {
+	return [
+		'category',
+		'post_tag',
+	];
+}
+```
+
+### Registering Post Meta
+
+Whilst there is no official way to register post meta, the scaffold provides an `after_register()` method that's called after the post type is registered.
+
+A useful pattern is:
+
+```php
+/**
+ * Run any code after the post type has been registered.
+ *
+ * @return void
+ */
+public function after_register() {
+	register_post_meta(
+		$this->get_name(),
+		'my_test_meta_key',
+		[
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'string',
+		]
+	);
+}
+```
+
+The `after_register()` method can also be useful to hook into anything else you may need to do, directly related to the registration of the post type.
+
+## Taxonomies
+
+To create a new taxonomy, you will need to create a new class that extends the `TenUpPlugin\Taxonomies\AbstractTaxonomy` class. This class will contain the configuration for the new taxonomy.
+
+Once you've extended the class (or copied the `Demo` class), you will need to define the following methods:
+
+- `get_name()` - This should return the name of the taxonomy as it will be used within the WordPress database.
+- `get_singular_label()` - This should return the singular label for the taxonomy.
+- `get_plural_label()` - This should return the plural label for the taxonomy.
+- `can_register()` - Whether the taxonomy should be actively registered or not. See [Registering Classes](./registering-classes.md).
+
+Once those are defined, ensure that `can_register()` is returning `true` and that you've [registered the taxonomy with a post type](#adding-taxonomies-to-a-post-type), then you should be able to see your taxonomy within the admin.
+
+### Heirarchical Taxonomies
+
+Should you need to create a heirarchical taxonomy, you can override the `is_hierarchical()` method and return `true`.
+
+```php
+/**
+ * Is the taxonomy hierarchical?
+ *
+ * @return bool
+ */
+public function is_hierarchical() {
+	return true;
+}
+```
+
+### Changing the Taxonomy Options
+
+The scaffold aims to set sensible defaults for the taxonomy options. Should you want to change these, you can handle it in much the same way as post types:
+
+a. Override the `get_options()` method and return an array of the options you want to enable.
+
+```php
+/**
+ * Get the options for the taxonomy.
+ *
+ * @return array
+ */
+public function get_options() {
+	$options = [
+		'labels'            => $this->get_labels(),
+		'hierarchical'      => $this->is_hierarchical(),
+		'show_ui'           => true,
+		'show_admin_column' => true,
+		'query_var'         => true,
+		'show_in_rest'      => true,
+		'public'            => true,
+	];
+
+	return $options;
+}
+```
+b. Merge your additional options into the base version
+
+```php
+/**
+ * Get the options for the taxonomy.
+ *
+ * @return array
+ */
+public function get_options() {
+	$options                = parent::get_options();
+	$options['public']      = false;
+
+	return $options;
+}
+```
+
+### Registering Taxonomy Meta
+
+Whilst there is no official way to register taxonomy meta, the scaffold provides an `after_register()` method that's called after the taxonomy is registered.
+
+A useful pattern is:
+
+```php
+/**
+ * Run any code after the taxonomy has been registered.
+ *
+ * @return void
+ */
+public function after_register() {
+	register_term_meta(
+		$this->get_name(),
+		'my_test_meta_key',
+		[
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'string',
+		]
+	);
+}
+```
+
+## Further Information
+
+I encourage you to look at the abstract post classes, whilst they aim to provide a sensible set of defaults, everything within them can be overidden, should it need to be.
+
+If you find yourself making the same changes across multiple classes or projects, please consider [opening a ticket](https://github.com/10up/wp-scaffold/issues/new?assignees=&labels=type%3Aenhancement&projects=&template=2-enhancement.yml) which describes those changes.
+That way we can look at updating the scaffold to help others in the future.

--- a/docs/creating-post-types-and-taxonomies.md
+++ b/docs/creating-post-types-and-taxonomies.md
@@ -19,9 +19,9 @@ Once you've extended the class (or copied the `Demo` class), you will need to de
 
 Once those are defined, ensure that `can_register()` is returning `true` and you should be able to see your post type within the admin.
 
-### Heirarchical Post Types
+### Hierarchical Post Types
 
-Should you need to create a heirarchical post type, you can override the `is_hierarchical()` method and return `true`.
+Should you need to create a hierarchical post type, you can override the `is_hierarchical()` method and return `true`.
 
 ```php
 /**
@@ -181,9 +181,9 @@ Once you've extended the class (or copied the `Demo` class), you will need to de
 
 Once those are defined, ensure that `can_register()` is returning `true` and that you've [registered the taxonomy with a post type](#adding-taxonomies-to-a-post-type), then you should be able to see your taxonomy within the admin.
 
-### Heirarchical Taxonomies
+### Hierarchical Taxonomies
 
-Should you need to create a heirarchical taxonomy, you can override the `is_hierarchical()` method and return `true`.
+Should you need to create a hierarchical taxonomy, you can override the `is_hierarchical()` method and return `true`.
 
 ```php
 /**

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractCorePostType.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractCorePostType.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * AbstractCorePostType
+ *
+ * @package TenUpPlugin
+ */
+
+namespace TenUpPlugin\PostTypes;
+
+/**
+ * Abstract class for core post types.
+ *
+ * This class is intended to be extended by post types that are part of core WordPress functionality.
+ * This allows for a more common interface for core post types and custom post types.
+ * It's unlikely that this class will need to be used directly.
+ */
+abstract class AbstractCorePostType extends AbstractPostType {
+
+	/**
+	 * Get the singular post type label.
+	 *
+	 * No-op for core post types since they are already registered by WordPress.
+	 *
+	 * @return string
+	 */
+	public function get_singular_label() {
+		return '';
+	}
+
+	/**
+	 * Get the plural post type label.
+	 *
+	 * No-op for core post types since they are already registered by WordPress.
+	 *
+	 * @return string
+	 */
+	public function get_plural_label() {
+		return '';
+	}
+
+	/**
+	 * Get the menu icon for the post type.
+	 *
+	 * No-op for core post types since they are already registered by WordPress.
+	 *
+	 * @return string
+	 */
+	public function get_menu_icon() {
+		return '';
+	}
+
+	/**
+	 * Checks whether the Module should run within the current context.
+	 *
+	 * True for core post types since they are already registered by WordPress.
+	 *
+	 * @return bool
+	 */
+	public function can_register() {
+		return true;
+	}
+
+	/**
+	 * Registers a post type and associates its taxonomies.
+	 *
+	 * @uses $this->get_name() to get the post's type name.
+	 * @return Bool Whether this theme has supports for this post type.
+	 */
+	public function register() {
+		$this->register_taxonomies();
+		$this->after_register();
+
+		return true;
+	}
+}

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
@@ -11,6 +11,31 @@ use TenUpPlugin\Module;
 
 /**
  * Abstract class for post types.
+ *
+ *  Usage:
+ *
+ *  class FooPostType extends AbstractPostType {
+ *
+ *      public function get_name() {
+ *          return 'custom-post-type';
+ *      }
+ *
+ *      public function get_singular_label() {
+ *          return 'Custom Post'
+ *      }
+ *
+ *      public function get_plural_label() {
+ *          return 'Custom Posts';
+ *      }
+ *
+ *      public function get_menu_icon() {
+ *          return 'embed-post';
+ *      }
+ *
+ *      public function can_register() {
+ *          return true;
+ *      }
+ *  }
  */
 abstract class AbstractPostType extends Module {
 

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
@@ -113,7 +113,7 @@ abstract class AbstractPostType extends Module {
 	 * @return array
 	 */
 	public function get_options() {
-		$options = [
+		return [
 			'labels'            => $this->get_labels(),
 			'public'            => true,
 			'has_archive'       => true,
@@ -126,8 +126,6 @@ abstract class AbstractPostType extends Module {
 			'menu_position'     => $this->get_menu_position(),
 			'hierarchical'      => $this->is_hierarchical(),
 		];
-
-		return $options;
 	}
 
 	/**
@@ -140,7 +138,7 @@ abstract class AbstractPostType extends Module {
 		$singular_label = $this->get_singular_label();
 
 		// phpcs:disable -- ignoring template strings without translators placeholder since this is dynamic
-		$labels = array(
+		$labels = [
 			'name'                     => $plural_label,
 			// Already translated via get_plural_label().
 			'singular_name'            => $singular_label,
@@ -169,7 +167,7 @@ abstract class AbstractPostType extends Module {
 			'item_updated'             => sprintf( __( '%s updated.', 'tenup-plugin' ), $singular_label ),
 			'menu_name'                => $plural_label,
 			'name_admin_bar'           => $singular_label,
-		);
+		];
 		// phpcs:enable
 
 		return $labels;

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
@@ -36,6 +36,35 @@ abstract class AbstractPostType extends Module {
 	abstract public function get_plural_label();
 
 	/**
+	 * Get the menu icon for the post type.
+	 *
+	 * This can be a base64 encoded SVG, a dashicons class or 'none' to leave it empty so it can be filled with CSS.
+	 *
+	 * @see https://developer.wordpress.org/resource/dashicons/
+	 *
+	 * @return string
+	 */
+	abstract public function get_menu_icon();
+
+	/**
+	 * Get the menu position for the post type.
+	 *
+	 * @return int|null
+	 */
+	public function get_menu_position() {
+		return null;
+	}
+
+	/**
+	 * Is the post type hierarchical?
+	 *
+	 * @return bool
+	 */
+	public function is_hierarchical() {
+		return false;
+	}
+
+	/**
 	 * Default post type supported feature names.
 	 *
 	 * @return array
@@ -68,6 +97,9 @@ abstract class AbstractPostType extends Module {
 			'show_in_nav_menus' => false,
 			'show_in_rest'      => true,
 			'supports'          => $this->get_editor_supports(),
+			'menu_icon'         => $this->get_menu_icon(),
+			'menu_position'     => $this->get_menu_position(),
+			'hierarchical'      => $this->is_hierarchical(),
 		];
 
 		return $options;

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
@@ -215,5 +215,4 @@ abstract class AbstractPostType extends Module {
 	public function after_register() {
 		// Do nothing.
 	}
-
 }

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * AbstractPostType
+ *
+ * @package TenUpPlugin
+ */
+
+namespace TenUpPlugin\PostTypes;
+
+use TenUpPlugin\Module;
+
+/**
+ * Abstract class for post types.
+ */
+abstract class AbstractPostType extends Module {
+
+	/**
+	 * Get the post type name.
+	 *
+	 * @return string
+	 */
+	abstract public function get_name();
+
+	/**
+	 * Get the singular post type label.
+	 *
+	 * @return string
+	 */
+	abstract public function get_singular_label();
+
+	/**
+	 * Get the plural post type label.
+	 *
+	 * @return string
+	 */
+	abstract public function get_plural_label();
+
+	/**
+	 * Default post type supported feature names.
+	 *
+	 * @return array
+	 */
+	public function get_editor_supports() {
+		$supports = [
+			'title',
+			'editor',
+			'author',
+			'thumbnail',
+			'excerpt',
+			'revisions',
+		];
+
+		return $supports;
+	}
+
+	/**
+	 * Get the options for the post type.
+	 *
+	 * @return array
+	 */
+	public function get_options() {
+		$options = [
+			'labels'            => $this->get_labels(),
+			'public'            => true,
+			'has_archive'       => true,
+			'show_ui'           => true,
+			'show_in_menu'      => true,
+			'show_in_nav_menus' => false,
+			'show_in_rest'      => true,
+			'supports'          => $this->get_editor_supports(),
+		];
+
+		return $options;
+	}
+
+	/**
+	 * Get the labels for the post type.
+	 *
+	 * @return array
+	 */
+	public function get_labels() {
+		$plural_label   = $this->get_plural_label();
+		$singular_label = $this->get_singular_label();
+
+		// phpcs:disable -- ignoring template strings without translators placeholder since this is dynamic
+		$labels = array(
+			'name'                     => $plural_label,
+			// Already translated via get_plural_label().
+			'singular_name'            => $singular_label,
+			// Already translated via get_singular_label().
+			'add_new_item'             => sprintf( __( 'Add New %s', 'tenup-plugin' ), $singular_label ),
+			'edit_item'                => sprintf( __( 'Edit %s', 'tenup-plugin' ), $singular_label ),
+			'new_item'                 => sprintf( __( 'New %s', 'tenup-plugin' ), $singular_label ),
+			'view_item'                => sprintf( __( 'View %s', 'tenup-plugin' ), $singular_label ),
+			'view_items'               => sprintf( __( 'View %s', 'tenup-plugin' ), $plural_label ),
+			'search_items'             => sprintf( __( 'Search %s', 'tenup-plugin' ), $plural_label ),
+			'not_found'                => sprintf( __( 'No %s found.', 'tenup-plugin' ), strtolower( $plural_label ) ),
+			'not_found_in_trash'       => sprintf( __( 'No %s found in Trash.', 'tenup-plugin' ), strtolower( $plural_label ) ),
+			'parent_item_colon'        => sprintf( __( 'Parent %s:', 'tenup-plugin' ), $plural_label ),
+			'all_items'                => sprintf( __( 'All %s', 'tenup-plugin' ), $plural_label ),
+			'archives'                 => sprintf( __( '%s Archives', 'tenup-plugin' ), $singular_label ),
+			'attributes'               => sprintf( __( '%s Attributes', 'tenup-plugin' ), $singular_label ),
+			'insert_into_item'         => sprintf( __( 'Insert into %s', 'tenup-plugin' ), strtolower( $singular_label ) ),
+			'uploaded_to_this_item'    => sprintf( __( 'Uploaded to this %s', 'tenup-plugin' ), strtolower( $singular_label ) ),
+			'filter_items_list'        => sprintf( __( 'Filter %s list', 'tenup-plugin' ), strtolower( $plural_label ) ),
+			'items_list_navigation'    => sprintf( __( '%s list navigation', 'tenup-plugin' ), $plural_label ),
+			'items_list'               => sprintf( __( '%s list', 'tenup-plugin' ), $plural_label ),
+			'item_published'           => sprintf( __( '%s published.', 'tenup-plugin' ), $singular_label ),
+			'item_published_privately' => sprintf( __( '%s published privately.', 'tenup-plugin' ), $singular_label ),
+			'item_reverted_to_draft'   => sprintf( __( '%s reverted to draft.', 'tenup-plugin' ), $singular_label ),
+			'item_scheduled'           => sprintf( __( '%s scheduled.', 'tenup-plugin' ), $singular_label ),
+			'item_updated'             => sprintf( __( '%s updated.', 'tenup-plugin' ), $singular_label ),
+			'menu_name'                => $plural_label,
+			'name_admin_bar'           => $singular_label,
+		);
+		// phpcs:enable
+
+		return $labels;
+	}
+
+	/**
+	 * Registers a post type and associates its taxonomies.
+	 *
+	 * @uses $this->get_name() to get the post's type name.
+	 * @return Bool Whether this theme has supports for this post type.
+	 */
+	public function register() {
+		$this->register_post_type();
+		$this->register_taxonomies();
+
+		$this->after_register();
+
+		return true;
+	}
+
+	/**
+	 * Registers the current post type with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_post_type() {
+		register_post_type(
+			$this->get_name(),
+			$this->get_options()
+		);
+	}
+
+	/**
+	 * Registers the taxonomies declared with the current post type.
+	 *
+	 * @return void
+	 */
+	public function register_taxonomies() {
+		$taxonomies = $this->get_supported_taxonomies();
+
+		$object_type = $this->get_name();
+
+		if ( ! empty( $taxonomies ) ) {
+			foreach ( $taxonomies as $taxonomy ) {
+				register_taxonomy_for_object_type(
+					$taxonomy,
+					$object_type
+				);
+			}
+		}
+	}
+
+	/**
+	 * Returns the default supported taxonomies. The subclass should declare the
+	 * Taxonomies that it supports here if required.
+	 *
+	 * @return array
+	 */
+	public function get_supported_taxonomies() {
+		return [];
+	}
+
+	/**
+	 * Run any code after the post type has been registered.
+	 *
+	 * @return void
+	 */
+	public function after_register() {
+		// Do nothing.
+	}
+
+}

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Demo.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Demo.php
@@ -40,6 +40,19 @@ class Demo extends AbstractPostType {
 	}
 
 	/**
+	 * Get the menu icon for the post type.
+	 *
+	 * This can be a base64 encoded SVG, a dashicons class or 'none' to leave it empty so it can be filled with CSS.
+	 *
+	 * @see https://developer.wordpress.org/resource/dashicons/
+	 *
+	 * @return string
+	 */
+	public function get_menu_icon() {
+		return 'dashicons-chart-pie';
+	}
+
+	/**
 	 * Can the class be registered?
 	 *
 	 * @return bool
@@ -68,4 +81,6 @@ class Demo extends AbstractPostType {
 	public function after_register() {
 		// Register any hooks/filters you need.
 	}
+
+
 }

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Demo.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Demo.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Demo Post Type
+ *
+ * @package TenUpPlugin
+ */
+
+namespace TenUpPlugin\PostTypes;
+
+/**
+ * Demo post type.
+ */
+class Demo extends AbstractPostType {
+
+	/**
+	 * Get the post type name.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return 'tenup-demo';
+	}
+
+	/**
+	 * Get the singular post type label.
+	 *
+	 * @return string
+	 */
+	public function get_singular_label() {
+		return esc_html__( 'Demo', 'tenup-plugin' );
+	}
+
+	/**
+	 * Get the plural post type label.
+	 *
+	 * @return string
+	 */
+	public function get_plural_label() {
+		return esc_html__( 'Demos', 'tenup-plugin' );
+	}
+
+	/**
+	 * Can the class be registered?
+	 *
+	 * @return bool
+	 */
+	public function can_register() {
+		return false;
+	}
+
+	/**
+	 * Returns the default supported taxonomies. The subclass should declare the
+	 * Taxonomies that it supports here if required.
+	 *
+	 * @return array
+	 */
+	public function get_supported_taxonomies() {
+		return [
+			'tenup-tax-demo',
+		];
+	}
+
+	/**
+	 * Run any code after the post type has been registered.
+	 *
+	 * @return void
+	 */
+	public function after_register() {
+		// Register any hooks/filters you need.
+	}
+}

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Demo.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Demo.php
@@ -81,6 +81,4 @@ class Demo extends AbstractPostType {
 	public function after_register() {
 		// Register any hooks/filters you need.
 	}
-
-
 }

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Page.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Page.php
@@ -7,10 +7,12 @@
 
 namespace TenUpPlugin\PostTypes;
 
+use TenUpPlugin\Module;
+
 /**
  * Page Post Type
  */
-class Page extends \TenUpPlugin\Module {
+class Page extends Module {
 
 	/**
 	 * Can the class be registered?

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Page.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Page.php
@@ -11,24 +11,37 @@ use TenUpPlugin\Module;
 
 /**
  * Page Post Type
+ *
+ * This class is a placeholder for the core Page post type.
+ * It's here to allow engineers to extend the core Page post type in the same way as custom post types.
  */
-class Page extends Module {
+class Page extends AbstractCorePostType {
 
 	/**
-	 * Can the class be registered?
+	 * Get the post type name.
 	 *
-	 * @return bool
+	 * @return string
 	 */
-	public function can_register() {
-		return true;
+	public function get_name() {
+		return 'page';
 	}
 
 	/**
-	 * Register hooks and filters.
+	 * Returns the default supported taxonomies. The subclass should declare the
+	 * Taxonomies that it supports here if required.
+	 *
+	 * @return array
+	 */
+	public function get_supported_taxonomies() {
+		return [];
+	}
+
+	/**
+	 * Run any code after the post type has been registered.
 	 *
 	 * @return void
 	 */
-	public function register() {
-		// Register any hooks/filters you need.
+	public function after_register() {
+		// Do nothing.
 	}
 }

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Page.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Page.php
@@ -7,8 +7,6 @@
 
 namespace TenUpPlugin\PostTypes;
 
-use TenUpPlugin\Module;
-
 /**
  * Page Post Type
  *

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Page.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Page.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Page Post Type
+ *
+ * @package TenUpPlugin
+ */
+
+namespace TenUpPlugin\PostTypes;
+
+/**
+ * Page Post Type
+ */
+class Page extends \TenUpPlugin\Module {
+
+	/**
+	 * Can the class be registered?
+	 *
+	 * @return bool
+	 */
+	public function can_register() {
+		return true;
+	}
+
+	/**
+	 * Register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		// Register any hooks/filters you need.
+	}
+}

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Post.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Post.php
@@ -7,28 +7,41 @@
 
 namespace TenUpPlugin\PostTypes;
 
-use TenUpPlugin\Module;
-
 /**
  * Post Post type.
+ *
+ * This class is a placeholder for the core Post post type.
+ * It's here to allow engineers to extend the core Post post type in the same way as custom post types.
  */
-class Post extends Module {
+class Post extends AbstractCorePostType {
 
 	/**
-	 * Can the class be registered?
+	 * Get the post type name.
 	 *
-	 * @return bool
+	 * @return string
 	 */
-	public function can_register() {
-		return true;
+	public function get_name() {
+		return 'post';
 	}
 
 	/**
-	 * Register hooks and filters.
+	 * Returns the default supported taxonomies. The subclass should declare the
+	 * Taxonomies that it supports here if required.
+	 *
+	 * Note: This will not remove the default taxonomies that are registered by core.
+	 *
+	 * @return array
+	 */
+	public function get_supported_taxonomies() {
+		return [];
+	}
+
+	/**
+	 * Run any code after the post type has been registered.
 	 *
 	 * @return void
 	 */
-	public function register() {
-		// Register any hooks/filters you need.
+	public function after_register() {
+		// Do nothing.
 	}
 }

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Post.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Post.php
@@ -7,10 +7,12 @@
 
 namespace TenUpPlugin\PostTypes;
 
+use TenUpPlugin\Module;
+
 /**
  * Post Post type.
  */
-class Post extends \TenUpPlugin\Module {
+class Post extends Module {
 
 	/**
 	 * Can the class be registered?

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Post.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Post.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Post Post type.
+ *
+ * @package TenUpPlugin
+ */
+
+namespace TenUpPlugin\PostTypes;
+
+/**
+ * Post Post type.
+ */
+class Post extends \TenUpPlugin\Module {
+
+	/**
+	 * Can the class be registered?
+	 *
+	 * @return bool
+	 */
+	public function can_register() {
+		return true;
+	}
+
+	/**
+	 * Register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		// Register any hooks/filters you need.
+	}
+}

--- a/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
+++ b/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
@@ -98,7 +98,7 @@ abstract class AbstractTaxonomy extends Module {
 	 * @return array
 	 */
 	public function get_options() {
-		return array(
+		return [
 			'labels'            => $this->get_labels(),
 			'hierarchical'      => $this->is_hierarchical(),
 			'show_ui'           => true,
@@ -106,7 +106,7 @@ abstract class AbstractTaxonomy extends Module {
 			'query_var'         => true,
 			'show_in_rest'      => true,
 			'public'            => true,
-		);
+		];
 	}
 
 	/**
@@ -119,7 +119,7 @@ abstract class AbstractTaxonomy extends Module {
 		$singular_label = $this->get_singular_label();
 
 		// phpcs:disable
-		$labels = array(
+		$labels = [
 			'name'                       => $plural_label, // Already translated via get_plural_label().
 			'singular_name'              => $singular_label, // Already translated via get_singular_label().
 			'search_items'               => sprintf( __( 'Search %s', 'tenup-plugin' ), $plural_label ),
@@ -135,7 +135,7 @@ abstract class AbstractTaxonomy extends Module {
 			'not_found'                  => sprintf( __( 'No %s found.', 'tenup-plugin' ), strtolower( $plural_label ) ),
 			'not_found_in_trash'         => sprintf( __( 'No %s found in Trash.', 'tenup-plugin' ), strtolower( $plural_label ) ),
 			'view_item'                  => sprintf( __( 'View %s', 'tenup-plugin' ), $singular_label ),
-		);
+		];
 		// phpcs:enable
 
 		return $labels;

--- a/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
+++ b/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
@@ -87,6 +87,8 @@ abstract class AbstractTaxonomy extends Module {
 			$this->get_options()
 		);
 
+		$this->after_register();
+
 		return true;
 	}
 
@@ -147,5 +149,14 @@ abstract class AbstractTaxonomy extends Module {
 	 */
 	public function get_post_types() {
 		return null;
+	}
+
+	/**
+	 * Run any code after the taxonomy has been registered.
+	 *
+	 * @return void
+	 */
+	public function after_register() {
+		// Do nothing.
 	}
 }

--- a/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
+++ b/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * AbstractTaxonomy
+ *
+ * @package TenUpPlugin
+ */
+
+namespace TenUpPlugin\Taxonomies;
+
+use TenUpPlugin\Module;
+
+/**
+ * Abstract Base Class for Taxonomies.
+ *
+ * Usage:
+ *
+ * class FooTaxonomy extends AbstractTaxonomy {
+ *
+ *     public function get_name() {
+ *         return 'tag';
+ *     }
+ *
+ *     public function get_singular_label() {
+ *         return 'Tag'
+ *     }
+ *
+ *     public function get_plural_label() {
+ *         return 'Tags';
+ *     }
+ *
+ *     public function can_register() {
+ *         return true;
+ *     }
+ * }
+ */
+abstract class AbstractTaxonomy extends Module {
+
+	/**
+	 * Used to alter the order in which clases are initialized.
+	 *
+	 * Lower number will be initialized first.
+	 *
+	 * @var int The priority of the module.
+	 */
+	public $load_order = 9;
+
+	/**
+	 * Get the taxonomy name.
+	 *
+	 * @return string
+	 */
+	abstract public function get_name();
+
+	/**
+	 * Get the singular taxonomy label.
+	 *
+	 * @return string
+	 */
+	abstract public function get_singular_label();
+
+	/**
+	 * Get the plural taxonomy label.
+	 *
+	 * @return string
+	 */
+	abstract public function get_plural_label();
+
+	/**
+	 * Register hooks and actions.
+	 *
+	 * @uses $this->get_name() to get the taxonomy's slug.
+	 * @return bool
+	 */
+	public function register() {
+		\register_taxonomy(
+			$this->get_name(),
+			$this->get_post_types(),
+			$this->get_options()
+		);
+
+		return true;
+	}
+
+	/**
+	 * Get the options for the taxonomy.
+	 *
+	 * @return array
+	 */
+	public function get_options() {
+		return array(
+			'labels'            => $this->get_labels(),
+			'hierarchical'      => false,
+			'show_ui'           => true,
+			'show_admin_column' => true,
+			'query_var'         => true,
+			'show_in_rest'      => true,
+			'public'            => true,
+		);
+	}
+
+	/**
+	 * Get the labels for the taxonomy.
+	 *
+	 * @return array
+	 */
+	public function get_labels() {
+		$plural_label   = $this->get_plural_label();
+		$singular_label = $this->get_singular_label();
+
+		// phpcs:disable
+		$labels = array(
+			'name'                       => $plural_label, // Already translated via get_plural_label().
+			'singular_name'              => $singular_label, // Already translated via get_singular_label().
+			'search_items'               => sprintf( __( 'Search %s', 'tenup-plugin' ), $plural_label ),
+			'popular_items'              => sprintf( __( 'Popular %s', 'tenup-plugin' ), $plural_label ),
+			'all_items'                  => sprintf( __( 'All %s', 'tenup-plugin' ), $plural_label ),
+			'edit_item'                  => sprintf( __( 'Edit %s', 'tenup-plugin' ), $singular_label ),
+			'update_item'                => sprintf( __( 'Update %s', 'tenup-plugin' ), $singular_label ),
+			'add_new_item'               => sprintf( __( 'Add %s', 'tenup-plugin' ), $singular_label ),
+			'new_item_name'              => sprintf( __( 'New %s Name', 'tenup-plugin' ), $singular_label ),
+			'separate_items_with_commas' => sprintf( __( 'Separate %s with commas', 'tenup-plugin' ), strtolower( $plural_label ) ),
+			'add_or_remove_items'        => sprintf( __( 'Add or remove %s', 'tenup-plugin' ), strtolower( $plural_label ) ),
+			'choose_from_most_used'      => sprintf( __( 'Choose from the most used %s', 'tenup-plugin' ), strtolower( $plural_label ) ),
+			'not_found'                  => sprintf( __( 'No %s found.', 'tenup-plugin' ), strtolower( $plural_label ) ),
+			'not_found_in_trash'         => sprintf( __( 'No %s found in Trash.', 'tenup-plugin' ), strtolower( $plural_label ) ),
+			'view_item'                  => sprintf( __( 'View %s', 'tenup-plugin' ), $singular_label ),
+		);
+		// phpcs:enable
+
+		return $labels;
+	}
+
+	/**
+	 * Setting the post types to null to ensure no post type is registered with
+	 * this taxonomy. Post Type classes declare their supported taxonomies.
+	 *
+	 * @return array|null
+	 */
+	public function get_post_types() {
+		return null;
+	}
+}

--- a/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
+++ b/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
@@ -66,6 +66,15 @@ abstract class AbstractTaxonomy extends Module {
 	abstract public function get_plural_label();
 
 	/**
+	 * Is the taxonomy hierarchical?
+	 *
+	 * @return bool
+	 */
+	public function is_hierarchical() {
+		return false;
+	}
+
+	/**
 	 * Register hooks and actions.
 	 *
 	 * @uses $this->get_name() to get the taxonomy's slug.
@@ -89,7 +98,7 @@ abstract class AbstractTaxonomy extends Module {
 	public function get_options() {
 		return array(
 			'labels'            => $this->get_labels(),
-			'hierarchical'      => false,
+			'hierarchical'      => $this->is_hierarchical(),
 			'show_ui'           => true,
 			'show_admin_column' => true,
 			'query_var'         => true,

--- a/mu-plugins/10up-plugin/includes/classes/Taxonomies/Demo.php
+++ b/mu-plugins/10up-plugin/includes/classes/Taxonomies/Demo.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Demo Taxonomy
+ *
+ * @package TenUpPlugin
+ */
+
+namespace TenUpPlugin\Taxonomies;
+
+/**
+ * Demo Taxonomy.
+ */
+class Demo extends AbstractTaxonomy {
+
+	/**
+	 * Get the taxonomy name.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return 'tenup-tax-demo';
+	}
+
+	/**
+	 * Get the singular taxonomy label.
+	 *
+	 * @return string
+	 */
+	public function get_singular_label() {
+		return esc_html__( 'Demo Term', 'tenup-plugin' );
+	}
+
+	/**
+	 * Get the plural taxonomy label.
+	 *
+	 * @return string
+	 */
+	public function get_plural_label() {
+		return esc_html__( 'Demo Terms', 'tenup-plugin' );
+	}
+
+	/**
+	 * Checks whether the Module should run within the current context.
+	 *
+	 * @return bool
+	 */
+	public function can_register() {
+		return false;
+	}
+}


### PR DESCRIPTION
### Description of the Change
This adds a PHP Scaffold for adding Post Types and Taxonomies to the scaffold. 

Whilst this isn't _needed_, it means that implementation would be very similar across projects, reducing cognitive load when context switching. It would also allow engineers to pick up newer projects much quicker.

Below is a screencast of me using this to create a new post type and taxonomy.
https://capture.dropbox.com/L7fP0jGYEvLobArN

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes 10up/wp-scaffold#175 

### How to test the Change
Check out the branch and try it out

### Changelog Entry
> Added - New PHP scaffolding for post types and taxonomies


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @darylldoyle 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
