### PR TITLE
Fix add new label

### DIFF
--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
@@ -143,6 +143,7 @@ abstract class AbstractPostType extends Module {
 			// Already translated via get_plural_label().
 			'singular_name'            => $singular_label,
 			// Already translated via get_singular_label().
+			'add_new'                  => sprintf( __( 'Add New %s', 'tenup-plugin' ), $singular_label ),
 			'add_new_item'             => sprintf( __( 'Add New %s', 'tenup-plugin' ), $singular_label ),
 			'edit_item'                => sprintf( __( 'Edit %s', 'tenup-plugin' ), $singular_label ),
 			'new_item'                 => sprintf( __( 'New %s', 'tenup-plugin' ), $singular_label ),


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This fixes an issue where the add new link was always showing "Add new Post" due to a missing label.
