### PR TITLE
Removing the $n function

### DIFF
--- a/mu-plugins/10up-plugin/includes/core.php
+++ b/mu-plugins/10up-plugin/includes/core.php
@@ -18,21 +18,17 @@ use TenUpPlugin\Utility;
  * @return void
  */
 function setup() {
-	$n = function ( $function ) {
-		return __NAMESPACE__ . "\\$function";
-	};
-
-	add_action( 'init', $n( 'i18n' ) );
-	add_action( 'init', $n( 'init' ), apply_filters( 'tenup_plugin_init_priority', 8 ) );
-	add_action( 'wp_enqueue_scripts', $n( 'scripts' ) );
-	add_action( 'wp_enqueue_scripts', $n( 'styles' ) );
-	add_action( 'admin_enqueue_scripts', $n( 'admin_scripts' ) );
-	add_action( 'admin_enqueue_scripts', $n( 'admin_styles' ) );
+	add_action( 'init', __NAMESPACE__ . '\\i18n' );
+	add_action( 'init', __NAMESPACE__ . '\\init', apply_filters( 'tenup_plugin_init_priority', 8 ) );
+	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\scripts' );
+	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\styles' );
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\admin_scripts' );
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\admin_styles' );
 
 	// Editor styles. add_editor_style() doesn't work outside of a theme.
-	add_filter( 'mce_css', $n( 'mce_css' ) );
+	add_filter( 'mce_css', __NAMESPACE__ . '\\mce_css' );
 	// Hook to allow async or defer on asset loading.
-	add_filter( 'script_loader_tag', $n( 'script_loader_tag' ), 10, 2 );
+	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\script_loader_tag', 10, 2 );
 
 	do_action( 'tenup_plugin_loaded' );
 }

--- a/mu-plugins/10up-plugin/includes/core.php
+++ b/mu-plugins/10up-plugin/includes/core.php
@@ -26,9 +26,9 @@ function setup() {
 	add_action( 'admin_enqueue_scripts', 'TenUpPlugin\Core\admin_styles' );
 
 	// Editor styles. add_editor_style() doesn't work outside of a theme.
-	add_filter( 'mce_css', __NAMESPACE__ . '\\mce_css' );
+	add_filter( 'mce_css', 'TenUpPlugin\Core\mce_css' );
 	// Hook to allow async or defer on asset loading.
-	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\script_loader_tag', 10, 2 );
+	add_filter( 'script_loader_tag', 'TenUpPlugin\Core\script_loader_tag', 10, 2 );
 
 	do_action( 'tenup_plugin_loaded' );
 }

--- a/mu-plugins/10up-plugin/includes/core.php
+++ b/mu-plugins/10up-plugin/includes/core.php
@@ -18,12 +18,12 @@ use TenUpPlugin\Utility;
  * @return void
  */
 function setup() {
-	add_action( 'init', __NAMESPACE__ . '\\i18n' );
-	add_action( 'init', __NAMESPACE__ . '\\init', apply_filters( 'tenup_plugin_init_priority', 8 ) );
-	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\scripts' );
-	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\styles' );
-	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\admin_scripts' );
-	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\admin_styles' );
+	add_action( 'init', 'TenUpPlugin\Core\i18n' );
+	add_action( 'init', 'TenUpPlugin\Core\init', apply_filters( 'tenup_plugin_init_priority', 8 ) );
+	add_action( 'wp_enqueue_scripts', 'TenUpPlugin\Core\scripts' );
+	add_action( 'wp_enqueue_scripts', 'TenUpPlugin\Core\styles' );
+	add_action( 'admin_enqueue_scripts', 'TenUpPlugin\Core\admin_scripts' );
+	add_action( 'admin_enqueue_scripts', 'TenUpPlugin\Core\admin_styles' );
 
 	// Editor styles. add_editor_style() doesn't work outside of a theme.
 	add_filter( 'mce_css', __NAMESPACE__ . '\\mce_css' );

--- a/themes/10up-theme/includes/blocks.php
+++ b/themes/10up-theme/includes/blocks.php
@@ -15,14 +15,10 @@ use TenUpTheme\Utility;
  * @return void
  */
 function setup() {
-	$n = function ( $function ) {
-		return __NAMESPACE__ . "\\$function";
-	};
-
-	add_action( 'enqueue_block_editor_assets', $n( 'blocks_editor_styles' ) );
-	add_action( 'init', $n( 'enqueue_block_specific_styles' ) );
-	add_action( 'init', $n( 'register_theme_blocks' ) );
-	add_action( 'init', $n( 'register_block_pattern_categories' ) );
+	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\blocks_editor_styles' );
+	add_action( 'init', __NAMESPACE__ . '\\enqueue_block_specific_styles' );
+	add_action( 'init', __NAMESPACE__ . '\\register_theme_blocks' );
+	add_action( 'init', __NAMESPACE__ . '\\register_block_pattern_categories' );
 }
 
 /**

--- a/themes/10up-theme/includes/blocks.php
+++ b/themes/10up-theme/includes/blocks.php
@@ -16,9 +16,9 @@ use TenUpTheme\Utility;
  */
 function setup() {
 	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\blocks_editor_styles' );
-	add_action( 'init', __NAMESPACE__ . '\\enqueue_block_specific_styles' );
-	add_action( 'init', __NAMESPACE__ . '\\register_theme_blocks' );
-	add_action( 'init', __NAMESPACE__ . '\\register_block_pattern_categories' );
+	add_action( 'init', 'TenUpTheme\Blocks\enqueue_block_specific_styles' );
+	add_action( 'init', 'TenUpTheme\Blocks\register_theme_blocks' );
+	add_action( 'init', 'TenUpTheme\Blocks\register_block_pattern_categories' );
 }
 
 /**

--- a/themes/10up-theme/includes/core.php
+++ b/themes/10up-theme/includes/core.php
@@ -16,18 +16,18 @@ use TenUpTheme\Utility;
  * @return void
  */
 function setup() {
-	add_action( 'init', __NAMESPACE__ . '\\init', apply_filters( 'tenup_theme_init_priority', 8 ) );
-	add_action( 'after_setup_theme', __NAMESPACE__ . '\\i18n' );
-	add_action( 'after_setup_theme', __NAMESPACE__ . '\\theme_setup' );
-	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\scripts' );
-	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\admin_styles' );
-	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\admin_scripts' );
-	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_block_editor_scripts' );
-	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\styles' );
-	add_action( 'wp_head', __NAMESPACE__ . '\\js_detection', 0 );
-	add_action( 'wp_head', __NAMESPACE__ . '\\embed_ct_css', 0 );
+	add_action( 'init', 'TenUpTheme\Core\init', apply_filters( 'tenup_theme_init_priority', 8 ) );
+	add_action( 'after_setup_theme', 'TenUpTheme\Core\i18n' );
+	add_action( 'after_setup_theme', 'TenUpTheme\Core\theme_setup' );
+	add_action( 'wp_enqueue_scripts', 'TenUpTheme\Core\scripts' );
+	add_action( 'admin_enqueue_scripts', 'TenUpTheme\Core\admin_styles' );
+	add_action( 'admin_enqueue_scripts', 'TenUpTheme\Core\admin_scripts' );
+	add_action( 'enqueue_block_editor_assets', 'TenUpTheme\Core\enqueue_block_editor_scripts' );
+	add_action( 'wp_enqueue_scripts', 'TenUpTheme\Core\styles' );
+	add_action( 'wp_head', 'TenUpTheme\Core\js_detection', 0 );
+	add_action( 'wp_head', 'TenUpTheme\Core\embed_ct_css', 0 );
 
-	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\script_loader_tag', 10, 2 );
+	add_filter( 'script_loader_tag', 'TenUpTheme\Core\script_loader_tag', 10, 2 );
 }
 
 /**

--- a/themes/10up-theme/includes/core.php
+++ b/themes/10up-theme/includes/core.php
@@ -16,22 +16,18 @@ use TenUpTheme\Utility;
  * @return void
  */
 function setup() {
-	$n = function ( $function ) {
-		return __NAMESPACE__ . "\\$function";
-	};
+	add_action( 'init', __NAMESPACE__ . '\\init', apply_filters( 'tenup_theme_init_priority', 8 ) );
+	add_action( 'after_setup_theme', __NAMESPACE__ . '\\i18n' );
+	add_action( 'after_setup_theme', __NAMESPACE__ . '\\theme_setup' );
+	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\scripts' );
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\admin_styles' );
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\admin_scripts' );
+	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_block_editor_scripts' );
+	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\styles' );
+	add_action( 'wp_head', __NAMESPACE__ . '\\js_detection', 0 );
+	add_action( 'wp_head', __NAMESPACE__ . '\\embed_ct_css', 0 );
 
-	add_action( 'init', $n( 'init' ), apply_filters( 'tenup_theme_init_priority', 8 ) );
-	add_action( 'after_setup_theme', $n( 'i18n' ) );
-	add_action( 'after_setup_theme', $n( 'theme_setup' ) );
-	add_action( 'wp_enqueue_scripts', $n( 'scripts' ) );
-	add_action( 'admin_enqueue_scripts', $n( 'admin_styles' ) );
-	add_action( 'admin_enqueue_scripts', $n( 'admin_scripts' ) );
-	add_action( 'enqueue_block_editor_assets', $n( 'enqueue_block_editor_scripts' ) );
-	add_action( 'wp_enqueue_scripts', $n( 'styles' ) );
-	add_action( 'wp_head', $n( 'js_detection' ), 0 );
-	add_action( 'wp_head', $n( 'embed_ct_css' ), 0 );
-
-	add_filter( 'script_loader_tag', $n( 'script_loader_tag' ), 10, 2 );
+	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\script_loader_tag', 10, 2 );
 }
 
 /**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This function makes it difficult for IDEs to work correctly as they’re dynamically defined. It also doesn’t play nice with static analysis systems.
<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #246 

### How to test the Change
Tested Locally

### Changelog Entry
- Removed - `$n` function, in preference of passing the namespace manually

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] ~I have updated the documentation accordingly.~
- [ ] ~I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.~
- [x] All new and existing tests pass.
