### PR TITLE
Fix/return types

### DIFF
--- a/mu-plugins/10up-plugin/composer.lock
+++ b/mu-plugins/10up-plugin/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "31e3ab009d94ede31cc48d6048807f1a",
+    "content-hash": "46290fd2c61c08f8be0aeb1139c048cc",
     "packages": [
         {
             "name": "haydenpierce/class-finder",
-            "version": "0.4.4",
+            "version": "0.5.3",
             "source": {
                 "type": "git",
                 "url": "git@gitlab.com:hpierce1102/ClassFinder.git",
-                "reference": "94c602870ddf8d4fa2d67fb9bae637d88f9bd76e"
+                "reference": "40703445c18784edcc6411703e7c3869af11ec8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/hpierce1102%2FClassFinder/repository/archive.zip?sha=94c602870ddf8d4fa2d67fb9bae637d88f9bd76e",
-                "reference": "94c602870ddf8d4fa2d67fb9bae637d88f9bd76e",
+                "url": "https://gitlab.com/api/v4/projects/hpierce1102%2FClassFinder/repository/archive.zip?sha=40703445c18784edcc6411703e7c3869af11ec8c",
+                "reference": "40703445c18784edcc6411703e7c3869af11ec8c",
                 "shasum": ""
             },
             "require": {
@@ -46,7 +46,7 @@
                 }
             ],
             "description": "A library that can provide of a list of classes in a given namespace",
-            "time": "2022-09-26T22:42:59+00:00"
+            "time": "2023-06-18T17:43:01+00:00"
         }
     ],
     "packages-dev": [],
@@ -59,5 +59,5 @@
         "php": ">=8.3"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
+++ b/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
@@ -46,14 +46,13 @@ class ModuleInitialization {
 	/**
 	 * The list of initialized classes.
 	 *
-	 * @var array
+	 * @var array<\TenUpPlugin\Module>
 	 */
 	protected $classes = [];
 
 	/**
 	 * Get all the TenUpPlugin plugin classes.
-	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	protected function get_classes() {
 		$class_finder = new ClassFinder();
@@ -78,6 +77,7 @@ class ModuleInitialization {
 			}
 
 			// Create a new reflection of the class.
+			// @phpstan-ignore-next-line
 			$reflection_class = new ReflectionClass( $class );
 
 			// Using reflection, check if the class can be initialized.
@@ -156,7 +156,7 @@ class ModuleInitialization {
 	/**
 	 * Get all the initialized classes.
 	 *
-	 * @return array
+	 * @return array<\TenUpPlugin\Module>
 	 */
 	public function get_all_classes() {
 		return $this->classes;

--- a/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
+++ b/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
@@ -94,6 +94,10 @@ class ModuleInitialization {
 			// Initialize the class.
 			$instantiated_class = new $class();
 
+			if ( ! $instantiated_class instanceof Module ) {
+				continue;
+			}
+
 			// Assign the classes into the order they should be initialized.
 			$load_class_order[ intval( $instantiated_class->load_order ) ][] = [
 				'slug'  => $slug,

--- a/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
+++ b/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
@@ -52,6 +52,7 @@ class ModuleInitialization {
 
 	/**
 	 * Get all the TenUpPlugin plugin classes.
+	 *
 	 * @return array<string>
 	 */
 	protected function get_classes() {

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
@@ -92,7 +92,7 @@ abstract class AbstractPostType extends Module {
 	/**
 	 * Default post type supported feature names.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public function get_editor_supports() {
 		$supports = [
@@ -110,7 +110,7 @@ abstract class AbstractPostType extends Module {
 	/**
 	 * Get the options for the post type.
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_options() {
 		return [
@@ -131,7 +131,7 @@ abstract class AbstractPostType extends Module {
 	/**
 	 * Get the labels for the post type.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public function get_labels() {
 		$plural_label   = $this->get_plural_label();
@@ -225,7 +225,7 @@ abstract class AbstractPostType extends Module {
 	 * Returns the default supported taxonomies. The subclass should declare the
 	 * Taxonomies that it supports here if required.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public function get_supported_taxonomies() {
 		return [];

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Demo.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Demo.php
@@ -65,7 +65,7 @@ class Demo extends AbstractPostType {
 	 * Returns the default supported taxonomies. The subclass should declare the
 	 * Taxonomies that it supports here if required.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public function get_supported_taxonomies() {
 		return [

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Page.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Page.php
@@ -28,7 +28,7 @@ class Page extends AbstractCorePostType {
 	 * Returns the default supported taxonomies. The subclass should declare the
 	 * Taxonomies that it supports here if required.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public function get_supported_taxonomies() {
 		return [];

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/Post.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/Post.php
@@ -30,7 +30,7 @@ class Post extends AbstractCorePostType {
 	 *
 	 * Note: This will not remove the default taxonomies that are registered by core.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public function get_supported_taxonomies() {
 		return [];

--- a/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
+++ b/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
@@ -145,10 +145,10 @@ abstract class AbstractTaxonomy extends Module {
 	 * Setting the post types to null to ensure no post type is registered with
 	 * this taxonomy. Post Type classes declare their supported taxonomies.
 	 *
-	 * @return array|null
+	 * @return array
 	 */
 	public function get_post_types() {
-		return null;
+		return [];
 	}
 
 	/**

--- a/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
+++ b/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
@@ -95,7 +95,7 @@ abstract class AbstractTaxonomy extends Module {
 	/**
 	 * Get the options for the taxonomy.
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_options() {
 		return [
@@ -112,7 +112,7 @@ abstract class AbstractTaxonomy extends Module {
 	/**
 	 * Get the labels for the taxonomy.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public function get_labels() {
 		$plural_label   = $this->get_plural_label();
@@ -145,7 +145,7 @@ abstract class AbstractTaxonomy extends Module {
 	 * Setting the post types to null to ensure no post type is registered with
 	 * this taxonomy. Post Type classes declare their supported taxonomies.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public function get_post_types() {
 		return [];

--- a/mu-plugins/10up-plugin/includes/core.php
+++ b/mu-plugins/10up-plugin/includes/core.php
@@ -96,7 +96,7 @@ function deactivate() {
 /**
  * The list of knows contexts for enqueuing scripts/styles.
  *
- * @return array
+ * @return array<string>
  */
 function get_enqueue_contexts() {
 	return [ 'admin', 'frontend', 'shared' ];

--- a/mu-plugins/10up-plugin/includes/core.php
+++ b/mu-plugins/10up-plugin/includes/core.php
@@ -108,12 +108,12 @@ function get_enqueue_contexts() {
  * @param string $script Script file name (no .js extension)
  * @param string $context Context for the script ('admin', 'frontend', or 'shared')
  *
- * @return string|WP_Error URL
+ * @return string URL
  */
 function script_url( $script, $context ) {
 
 	if ( ! in_array( $context, get_enqueue_contexts(), true ) ) {
-		return new WP_Error( 'invalid_enqueue_context', 'Invalid $context specified in TenUpPlugin script loader.' );
+		throw new \RuntimeException( 'Invalid $context specified in TenUpPlugin script loader.' );
 	}
 
 	return TENUP_PLUGIN_URL . "dist/js/{$script}.js";
@@ -130,7 +130,7 @@ function script_url( $script, $context ) {
 function style_url( $stylesheet, $context ) {
 
 	if ( ! in_array( $context, get_enqueue_contexts(), true ) ) {
-		return new WP_Error( 'invalid_enqueue_context', 'Invalid $context specified in TenUpPlugin stylesheet loader.' );
+		throw new \RuntimeException( 'Invalid $context specified in TenUpPlugin stylesheet loader.' );
 	}
 
 	return TENUP_PLUGIN_URL . "dist/css/{$stylesheet}.css";
@@ -259,7 +259,7 @@ function mce_css( $stylesheets ) {
  * @link https://core.trac.wordpress.org/ticket/12009
  * @param string $tag    The script tag.
  * @param string $handle The script handle.
- * @return string
+ * @return string|null
  */
 function script_loader_tag( $tag, $handle ) {
 	$script_execution = wp_scripts()->get_data( $handle, 'script_execution' );

--- a/mu-plugins/10up-plugin/includes/core.php
+++ b/mu-plugins/10up-plugin/includes/core.php
@@ -108,6 +108,8 @@ function get_enqueue_contexts() {
  * @param string $script Script file name (no .js extension)
  * @param string $context Context for the script ('admin', 'frontend', or 'shared')
  *
+ * @throws \RuntimeException If an invalid $context is specified.
+ *
  * @return string URL
  */
 function script_url( $script, $context ) {
@@ -124,6 +126,8 @@ function script_url( $script, $context ) {
  *
  * @param string $stylesheet Stylesheet file name (no .css extension)
  * @param string $context Context for the script ('admin', 'frontend', or 'shared')
+ *
+ * @throws \RuntimeException If an invalid $context is specified.
  *
  * @return string URL
  */
@@ -269,7 +273,7 @@ function script_loader_tag( $tag, $handle ) {
 	}
 
 	if ( 'async' !== $script_execution && 'defer' !== $script_execution ) {
-		return $tag; // _doing_it_wrong()?
+		return $tag;
 	}
 
 	// Abort adding async/defer for scripts that have this script as a dependency. _doing_it_wrong()?

--- a/mu-plugins/10up-plugin/includes/utility.php
+++ b/mu-plugins/10up-plugin/includes/utility.php
@@ -26,7 +26,10 @@ function get_asset_info( $slug, $attribute = null ) {
 	} elseif ( file_exists( TENUP_PLUGIN_PATH . 'dist/css/' . $slug . '.asset.php' ) ) {
 		$asset = require TENUP_PLUGIN_PATH . 'dist/css/' . $slug . '.asset.php';
 	} else {
-		$asset = [ 'version' => TENUP_PLUGIN_VERSION, 'dependencies' => [] ];
+		$asset = [
+			'version'      => TENUP_PLUGIN_VERSION,
+			'dependencies' => [],
+		];
 	}
 
 	// @var <array{version: string, dependencies: array<string>}> $asset

--- a/mu-plugins/10up-plugin/includes/utility.php
+++ b/mu-plugins/10up-plugin/includes/utility.php
@@ -18,7 +18,7 @@ namespace TenUpPlugin\Utility;
  *
  * @param string $slug Asset slug as defined in build/webpack configuration
  * @param string $attribute Optional attribute to get. Can be version or dependencies
- * @return string|array
+ * @return ($attribute is null ? array{version: string, dependencies: array<string>} : $attribute is 'dependencies' ? array<string> : string)
  */
 function get_asset_info( $slug, $attribute = null ) {
 	if ( file_exists( TENUP_PLUGIN_PATH . 'dist/js/' . $slug . '.asset.php' ) ) {
@@ -26,8 +26,10 @@ function get_asset_info( $slug, $attribute = null ) {
 	} elseif ( file_exists( TENUP_PLUGIN_PATH . 'dist/css/' . $slug . '.asset.php' ) ) {
 		$asset = require TENUP_PLUGIN_PATH . 'dist/css/' . $slug . '.asset.php';
 	} else {
-		return null;
+		$asset = [ 'version' => TENUP_PLUGIN_VERSION, 'dependencies' => [] ];
 	}
+
+	// @var <array{version: string, dependencies: array<string>}> $asset
 
 	if ( ! empty( $attribute ) && isset( $asset[ $attribute ] ) ) {
 		return $asset[ $attribute ];

--- a/mu-plugins/10up-plugin/plugin.php
+++ b/mu-plugins/10up-plugin/plugin.php
@@ -30,7 +30,10 @@ $is_local     = $is_local_env || $is_local_url;
 
 if ( $is_local && file_exists( __DIR__ . '/dist/fast-refresh.php' ) ) {
 	require_once __DIR__ . '/dist/fast-refresh.php';
-	TenUpToolkit\set_dist_url_path( basename( __DIR__ ), TENUP_PLUGIN_DIST_URL, TENUP_PLUGIN_DIST_PATH );
+
+	if ( function_exists( 'TenUpToolkit\set_dist_url_path' ) ) {
+		TenUpToolkit\set_dist_url_path( basename( __DIR__ ), TENUP_PLUGIN_DIST_URL, TENUP_PLUGIN_DIST_PATH );
+	}
 }
 
 // Require Composer autoloader if it exists.

--- a/themes/10up-theme/functions.php
+++ b/themes/10up-theme/functions.php
@@ -21,7 +21,10 @@ $is_local     = $is_local_env || $is_local_url;
 
 if ( $is_local && file_exists( __DIR__ . '/dist/fast-refresh.php' ) ) {
 	require_once __DIR__ . '/dist/fast-refresh.php';
-	TenUpToolkit\set_dist_url_path( basename( __DIR__ ), TENUP_THEME_DIST_URL, TENUP_THEME_DIST_PATH );
+
+	if ( function_exists( 'TenUpToolkit\set_dist_url_path' ) ) {
+		TenUpToolkit\set_dist_url_path( basename( __DIR__ ), TENUP_THEME_DIST_URL, TENUP_THEME_DIST_PATH );
+	}
 }
 
 require_once TENUP_THEME_INC . 'core.php';

--- a/themes/10up-theme/includes/blocks.php
+++ b/themes/10up-theme/includes/blocks.php
@@ -31,6 +31,10 @@ function register_theme_blocks() {
 	if ( file_exists( TENUP_THEME_BLOCK_DIST_DIR ) ) {
 		$block_json_files = glob( TENUP_THEME_BLOCK_DIST_DIR . '*/block.json' );
 
+		if ( empty( $block_json_files ) ) {
+			return;
+		}
+
 		// auto register all blocks that were found.
 		foreach ( $block_json_files as $filename ) {
 
@@ -101,6 +105,10 @@ function blocks_editor_styles() {
  */
 function enqueue_block_specific_styles() {
 	$stylesheets = glob( TENUP_THEME_DIST_PATH . 'blocks/autoenqueue/**/*.css' );
+
+	if ( empty( $stylesheets ) ) {
+		return;
+	}
 
 	foreach ( $stylesheets as $stylesheet_path ) {
 		$block_type = str_replace( TENUP_THEME_DIST_PATH . 'blocks/autoenqueue/', '', $stylesheet_path );

--- a/themes/10up-theme/includes/classes/ModuleInitialization.php
+++ b/themes/10up-theme/includes/classes/ModuleInitialization.php
@@ -46,14 +46,14 @@ class ModuleInitialization {
 	/**
 	 * The list of initialized classes.
 	 *
-	 * @var array
+	 * @var array<\TenUpTheme\Module>
 	 */
 	protected $classes = [];
 
 	/**
 	 * Get all the TenUpTheme plugin classes.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	protected function get_classes() {
 		$class_finder = new ClassFinder();
@@ -79,6 +79,7 @@ class ModuleInitialization {
 			}
 
 			// Create a new reflection of the class.
+			// @phpstan-ignore-next-line
 			$reflection_class = new ReflectionClass( $class );
 
 			// Using reflection, check if the class can be initialized.
@@ -157,7 +158,7 @@ class ModuleInitialization {
 	/**
 	 * Get all the initialized classes.
 	 *
-	 * @return array
+	 * @return array<\TenUpTheme\Module>
 	 */
 	public function get_all_classes() {
 		return $this->classes;

--- a/themes/10up-theme/includes/classes/ModuleInitialization.php
+++ b/themes/10up-theme/includes/classes/ModuleInitialization.php
@@ -95,6 +95,10 @@ class ModuleInitialization {
 			// Initialize the class.
 			$instantiated_class = new $class();
 
+			if ( ! $instantiated_class instanceof Module ) {
+				continue;
+			}
+
 			// Assign the classes into the order they should be initialized.
 			$load_class_order[ intval( $instantiated_class->load_order ) ][] = [
 				'slug'  => $slug,

--- a/themes/10up-theme/includes/core.php
+++ b/themes/10up-theme/includes/core.php
@@ -72,6 +72,8 @@ function i18n() {
 
 /**
  * Sets up theme defaults and registers support for various WordPress features.
+ *
+ * @return void
  */
 function theme_setup() {
 	add_theme_support( 'automatic-feed-links' );
@@ -258,7 +260,7 @@ function js_detection() {
  * @link https://core.trac.wordpress.org/ticket/12009
  * @param string $tag    The script tag.
  * @param string $handle The script handle.
- * @return string
+ * @return string|null
  */
 function script_loader_tag( $tag, $handle ) {
 	$script_execution = wp_scripts()->get_data( $handle, 'script_execution' );
@@ -301,7 +303,7 @@ function script_loader_tag( $tag, $handle ) {
  */
 function embed_ct_css() {
 
-	$debug_performance = rest_sanitize_boolean( filter_input( INPUT_GET, 'debug_perf', FILTER_SANITIZE_NUMBER_INT ) );
+	$debug_performance = rest_sanitize_boolean( boolval( filter_input( INPUT_GET, 'debug_perf', FILTER_SANITIZE_NUMBER_INT ) ) );
 
 	if ( ! $debug_performance ) {
 		return;

--- a/themes/10up-theme/includes/overrides.php
+++ b/themes/10up-theme/includes/overrides.php
@@ -52,8 +52,8 @@ function setup() {
  *
  * @link https://developer.wordpress.org/reference/hooks/tiny_mce_plugins/
  *
- * @param  array $plugins An array of default TinyMCE plugins.
- * @return array          An array of TinyMCE plugins, without wpemoji.
+ * @param  array<string> $plugins An array of default TinyMCE plugins.
+ * @return array<string>          An array of TinyMCE plugins, without wpemoji.
  */
 function disable_emojis_tinymce( $plugins ) {
 	if ( is_array( $plugins ) && in_array( 'wpemoji', $plugins, true ) ) {
@@ -68,9 +68,9 @@ function disable_emojis_tinymce( $plugins ) {
  *
  * @link https://developer.wordpress.org/reference/hooks/emoji_svg_url/
  *
- * @param  array  $urls          URLs to print for resource hints.
+ * @param  array<string>  $urls          URLs to print for resource hints.
  * @param  string $relation_type The relation type the URLs are printed for.
- * @return array                 Difference betwen the two arrays.
+ * @return array<string>                 Difference betwen the two arrays.
  */
 function disable_emoji_dns_prefetch( $urls, $relation_type ) {
 	if ( 'dns-prefetch' === $relation_type ) {

--- a/themes/10up-theme/includes/overrides.php
+++ b/themes/10up-theme/includes/overrides.php
@@ -68,8 +68,8 @@ function disable_emojis_tinymce( $plugins ) {
  *
  * @link https://developer.wordpress.org/reference/hooks/emoji_svg_url/
  *
- * @param  array<string>  $urls          URLs to print for resource hints.
- * @param  string $relation_type The relation type the URLs are printed for.
+ * @param  array<string> $urls          URLs to print for resource hints.
+ * @param  string        $relation_type The relation type the URLs are printed for.
  * @return array<string>                 Difference betwen the two arrays.
  */
 function disable_emoji_dns_prefetch( $urls, $relation_type ) {

--- a/themes/10up-theme/includes/utility.php
+++ b/themes/10up-theme/includes/utility.php
@@ -41,7 +41,7 @@ function get_asset_info( $slug, $attribute = null ) {
  *
  * @param string $path the path to your CSS variables file
  *
- * @return array
+ * @return array<string>
  */
 function get_colors( $path ) {
 

--- a/themes/10up-theme/includes/utility.php
+++ b/themes/10up-theme/includes/utility.php
@@ -26,7 +26,10 @@ function get_asset_info( $slug, $attribute = null ) {
 	} elseif ( file_exists( TENUP_THEME_PATH . 'dist/css/' . $slug . '.asset.php' ) ) {
 		$asset = require TENUP_THEME_PATH . 'dist/css/' . $slug . '.asset.php';
 	} else {
-		$asset = [ 'version' => TENUP_THEME_VERSION, 'dependencies' => [] ];
+		$asset = [
+			'version'      => TENUP_THEME_VERSION,
+			'dependencies' => [],
+		];
 	}
 
 	if ( ! empty( $attribute ) && isset( $asset[ $attribute ] ) ) {
@@ -40,6 +43,8 @@ function get_asset_info( $slug, $attribute = null ) {
  * Extract colors from a CSS or Sass file
  *
  * @param string $path the path to your CSS variables file
+ *
+ * @throws \RuntimeException If the file is not found or could not be read
  *
  * @return array<string>
  */

--- a/themes/10up-theme/includes/utility.php
+++ b/themes/10up-theme/includes/utility.php
@@ -18,7 +18,7 @@ namespace TenUpTheme\Utility;
  *
  * @param string $slug Asset slug as defined in build/webpack configuration
  * @param string $attribute Optional attribute to get. Can be version or dependencies
- * @return string|array
+ * @return ($attribute is null ? array{version: string, dependencies: array<string>} : $attribute is 'dependencies' ? array<string> : string)
  */
 function get_asset_info( $slug, $attribute = null ) {
 	if ( file_exists( TENUP_THEME_PATH . 'dist/js/' . $slug . '.asset.php' ) ) {
@@ -26,7 +26,7 @@ function get_asset_info( $slug, $attribute = null ) {
 	} elseif ( file_exists( TENUP_THEME_PATH . 'dist/css/' . $slug . '.asset.php' ) ) {
 		$asset = require TENUP_THEME_PATH . 'dist/css/' . $slug . '.asset.php';
 	} else {
-		return null;
+		$asset = [ 'version' => TENUP_THEME_VERSION, 'dependencies' => [] ];
 	}
 
 	if ( ! empty( $attribute ) && isset( $asset[ $attribute ] ) ) {
@@ -40,6 +40,8 @@ function get_asset_info( $slug, $attribute = null ) {
  * Extract colors from a CSS or Sass file
  *
  * @param string $path the path to your CSS variables file
+ *
+ * @return array
  */
 function get_colors( $path ) {
 
@@ -47,6 +49,11 @@ function get_colors( $path ) {
 
 	if ( file_exists( $dir . $path ) ) {
 		$css_vars = file_get_contents( $dir . $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+		if ( false === $css_vars ) {
+			throw new \RuntimeException( 'Could not read CSS variables file.' );
+		}
+
 		// HEX(A) | RGB(A) | HSL(A) - rgba & hsla alpha as decimal or percentage
 		// https://regex101.com/r/l7AZ8R/
 		// this is a loose match and will accept almost anything within () for rgb(a) & hsl(a)
@@ -55,6 +62,8 @@ function get_colors( $path ) {
 
 		return $matches[0];
 	}
+
+	throw new \RuntimeException( 'CSS variables file not found.' );
 }
 
 /**
@@ -82,7 +91,7 @@ function adjust_brightness( $hex, $steps ) {
 	foreach ( $color_parts as $color ) {
 		$color   = hexdec( $color ); // Convert to decimal
 		$color   = max( 0, min( 255, $color + $steps ) ); // Adjust color
-		$return .= str_pad( dechex( $color ), 2, '0', STR_PAD_LEFT ); // Make two char hex code
+		$return .= str_pad( dechex( intval( $color ) ), 2, '0', STR_PAD_LEFT ); // Make two char hex code
 	}
 
 	return $return;

--- a/themes/10up-theme/search.php
+++ b/themes/10up-theme/search.php
@@ -28,6 +28,7 @@ get_header(); ?>
 						the_post_thumbnail();
 					}
 
+					// @phpstan-ignore-next-lines
 					the_title( '<span itemprop="name"><a href="' . esc_url( get_permalink() ) . '" itemprop="url">', '</a></span>' );
 					?>
 					<div itemprop="description">


### PR DESCRIPTION
### Description of the Change
This PR goes through our scaffold and adds the correct return types to methods and functions. This will increase the reliability of static analysis available to engineers, either via their IDEs or a tool like PHPStan.

Additionally, it ensures that _we_, as a company, are starting engineers off on the best foot possible, with no potential errors caused by incorrect return types.

Finally, there are some places where I've added additional defensive coding to ensure that we don't inadvertently trigger errors.

### How to test the Change
Test the scaffold locally.

### Changelog Entry
* Fixed - Return types


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @darylldoyle 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] ~I have updated the documentation accordingly.~
- [ ] ~I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.~
- [ ] All new and existing tests pass.
