### PR TITLE
Tooling/enforce type quality

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Run PHPCS
         run: composer lint
+
+      - name: Run PHPStan
+        run: composer static

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -30,7 +30,7 @@ jobs:
         run: composer validate --strict --working-dir=mu-plugins/10up-plugin
 
       - name: Validate Theme composer.json and composer.lock
-        run: composer validate --strict --working-dir=wp-content/themes/10up-theme
+        run: composer validate --strict --working-dir=themes/10up-theme
 
       - name: Cache Composer packages
         id: composer-cache

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,8 +23,14 @@ jobs:
           php-version: '8.3'
           tools: composer:v2
 
-      - name: Validate composer.json and composer.lock
+      - name: Validate Root composer.json and composer.lock
         run: composer validate --strict
+
+      - name: Validate Plugin composer.json and composer.lock
+        run: composer validate --strict --working-dir=mu-plugins/10up-plugin
+
+      - name: Validate Theme composer.json and composer.lock
+        run: composer validate --strict --working-dir=wp-content/themes/10up-theme
 
       - name: Cache Composer packages
         id: composer-cache
@@ -35,8 +41,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-php-
 
-      - name: Install dependencies
+      - name: Install Root dependencies
         run: composer install --prefer-dist --no-progress
+
+      - name: Install Plugin dependencies
+        run: composer install --prefer-dist --no-progress --working-dir=mu-plugins/10up-plugin
+
+      - name: Install Theme dependencies
+        run: composer install --prefer-dist --no-progress --working-dir=themes/10up-theme
 
       - name: Run PHPCS
         run: composer lint

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,17 @@
     "wpackagist-plugin/debug-bar": "*",
     "wpackagist-plugin/query-monitor":"*",
     "wpackagist-plugin/debug-bar-slow-actions":"*",
-    "phpcompatibility/php-compatibility": "dev-develop as 9.99.99"
+    "phpcompatibility/php-compatibility": "dev-develop as 9.99.99",
+    "szepeviktor/phpstan-wordpress": "^1.3",
+    "php-stubs/wp-cli-stubs": "^2.11"
   },
   "scripts": {
     "lint": "phpcs .",
-    "lint-fix": "phpcbf ."
+    "lint-fix": "phpcbf .",
+    "static": [
+      "Composer\\Config::disableProcessTimeout",
+      "phpstan --memory-limit=1G"
+    ]
   },
   "extra": {
     "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "wpackagist-plugin/debug-bar-slow-actions":"*",
     "phpcompatibility/php-compatibility": "dev-develop as 9.99.99",
     "szepeviktor/phpstan-wordpress": "^1.3",
-    "php-stubs/wp-cli-stubs": "^2.11"
+    "php-stubs/wp-cli-stubs": "^2.11",
+    "phpstan/phpstan-deprecation-rules": "^1.2"
   },
   "scripts": {
     "lint": "phpcs .",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18428fb867a88e52e3f9cbd67bc45219",
+    "content-hash": "fe80ed79f9ba2a453e44e2316e69122b",
     "packages": [],
     "packages-dev": [
         {
@@ -872,6 +872,53 @@
                 }
             ],
             "time": "2024-11-28T22:13:23+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "f94d246cc143ec5a23da868f8f7e1393b50eaa82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/f94d246cc143ec5a23da868f8f7e1393b50eaa82",
+                "reference": "f94d246cc143ec5a23da868f8f7e1393b50eaa82",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.12"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.1"
+            },
+            "time": "2024-09-11T15:52:35+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "190119b38e0e42df3be015f20fa0b779",
+    "content-hash": "18428fb867a88e52e3f9cbd67bc45219",
     "packages": [],
     "packages-dev": [
         {
@@ -326,17 +326,109 @@
             "time": "2023-01-05T11:28:13+00:00"
         },
         {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "83448e918bf06d1ed3d67ceb6a985fc266a02fd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/83448e918bf06d1ed3d67ceb6a985fc266a02fd1",
+                "reference": "83448e918bf06d1ed3d67ceb6a985fc266a02fd1",
+                "shasum": ""
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^4.13",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "^5.4.1",
+                "phpstan/phpstan": "^1.11",
+                "phpunit/phpunit": "^9.5",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.7.1"
+            },
+            "time": "2024-11-24T03:57:09+00:00"
+        },
+        {
+            "name": "php-stubs/wp-cli-stubs",
+            "version": "v2.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wp-cli-stubs.git",
+                "reference": "f27ff9e8e29d7962cb070e58de70dfaf63183007"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wp-cli-stubs/zipball/f27ff9e8e29d7962cb070e58de70dfaf63183007",
+                "reference": "f27ff9e8e29d7962cb070e58de70dfaf63183007",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0"
+            },
+            "require-dev": {
+                "php": "~7.3 || ~8.0",
+                "php-stubs/generator": "^0.8.0"
+            },
+            "suggest": {
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WP-CLI function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wp-cli-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress",
+                "wp-cli"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wp-cli-stubs/issues",
+                "source": "https://github.com/php-stubs/wp-cli-stubs/tree/v2.11.0"
+            },
+            "time": "2024-11-25T10:09:13+00:00"
+        },
+        {
             "name": "phpcompatibility/php-compatibility",
             "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "3f79f96be9289a49eb85a4db3e8f5b7d55ba06d2"
+                "reference": "02835e45d27f5d0ed1642d5c8a5e8bfd2c7d7796"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/3f79f96be9289a49eb85a4db3e8f5b7d55ba06d2",
-                "reference": "3f79f96be9289a49eb85a4db3e8f5b7d55ba06d2",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/02835e45d27f5d0ed1642d5c8a5e8bfd2c7d7796",
+                "reference": "02835e45d27f5d0ed1642d5c8a5e8bfd2c7d7796",
                 "shasum": ""
             },
             "require": {
@@ -413,7 +505,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-10-13T19:18:49+00:00"
+            "time": "2024-11-30T16:25:00+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -724,17 +816,75 @@
             "time": "2024-05-20T13:34:27+00:00"
         },
         {
-            "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.19",
+            "name": "phpstan/phpstan",
+            "version": "1.12.12",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1"
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1",
-                "reference": "bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0",
+                "reference": "b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-11-28T22:13:23+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.21",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "eb2b351927098c24860daa7484e290d3eed693be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/eb2b351927098c24860daa7484e290d3eed693be",
+                "reference": "eb2b351927098c24860daa7484e290d3eed693be",
                 "shasum": ""
             },
             "require": {
@@ -745,9 +895,9 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
                 "phpcsstandards/phpcsdevcs": "^1.1",
                 "phpstan/phpstan": "^1.7",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
                 "sirbrillig/phpcs-import-detection": "^1.1",
-                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -779,7 +929,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2024-06-26T20:08:34+00:00"
+            "time": "2024-12-02T16:37:49+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -860,6 +1010,145 @@
                 }
             ],
             "time": "2024-11-16T12:02:36+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v1.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+                "reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
+                "phpstan/phpstan": "^1.10.31",
+                "symfony/polyfill-php73": "^1.12.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1.14",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.2",
+                "phpunit/phpunit": "^8.0 || ^9.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.3.5"
+            },
+            "time": "2024-06-28T22:27:19+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -965,15 +1254,15 @@
         },
         {
             "name": "wpackagist-plugin/query-monitor",
-            "version": "3.16.4",
+            "version": "3.17.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/query-monitor/",
-                "reference": "tags/3.16.4"
+                "reference": "tags/3.17.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.16.4.zip"
+                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.17.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -1000,5 +1289,5 @@
         "php": ">=8.3"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -1,0 +1,151 @@
+# PHPStan in WordPress Projects
+
+PHPStan is a static analysis tool for PHP that helps you catch bugs and improve code quality without even running your code. This guide will walk you through setting up and using PHPStan in your WordPress project, specifically tailored to the 10up Scaffold.
+
+## Getting Started
+
+PHPStan is already installed within the scaffold, so you only need to configure it for your new project.
+
+## Configuring PHPStan
+
+The configuration file for PHPStan is named `phpstan.neon`. It contains all the settings PHPStan will use when analyzing your code. Below is an example configuration file already included in the scaffold:
+
+```neon
+includes:
+	- phpstan/default.neon
+
+parameters:
+	paths:
+		- themes/10up-theme
+		- mu-plugins/10up-plugin
+		- mu-plugins/10up-plugin-loader.php
+```
+
+- **`paths`**: Directories or files to analyze.
+
+## Running PHPStan
+
+Once configured, you can run PHPStan with:
+
+```bash
+composer run static
+```
+
+This command will scan the files defined in your `phpstan.neon` file and output any issues it finds.
+
+## Dealing with PHPStan Errors
+
+When integrating PHPStan into an existing codebase, you may encounter a large number of errors. The scaffold is set up with a PHPStan level of 9, the highest in V1 of PHPStan. Here are two effective strategies to manage them:
+
+### Lower the PHPStan Level
+
+To start small, you can reduce the PHPStan level. This decreases the strictness and flags only the most severe issues. Here’s how to lower the level:
+
+```neon
+includes:
+	- phpstan/default.neon
+
+parameters:
+	level: 4   <--- Add the level here.
+	paths:
+		- themes/10up-theme
+		- mu-plugins/10up-plugin
+		- mu-plugins/10up-plugin-loader.php
+```
+
+The recommended workflow is to start at level 4, fix all issues, and then gradually increase the level, addressing errors as you go.
+
+See more about PHPStan levels here: [Levels of PHPStan](https://phpstan.org/user-guide/rule-levels).
+
+### Create a Baseline
+
+PHPStan allows you to create a "baseline" file to temporarily ignore existing errors. This is especially useful for legacy projects. You can generate a baseline with:
+
+```bash
+composer run static -- --generate-baseline
+```
+
+This creates a `phpstan-baseline.neon` file. Add it to your `phpstan.neon` configuration like this:
+
+```neon
+includes:
+	- phpstan/default.neon
+	- phpstan-baseline.neon
+```
+
+Commit the baseline file to your repository. Over time, as you address the issues in your codebase, you can update or remove the baseline.
+
+## Analyzing Third-Party Code
+
+When working with third-party code (e.g., vendor packages or dependencies), PHPStan may report errors in files you don’t control. To exclude these from analysis, use the `excludePaths` and `analyseAndScan` parameters in your configuration:
+
+```neon
+parameters:
+	excludePaths:
+		analyseAndScan:
+			- path/to/files/to/ignore
+			- path/to/more/files/to/ignore
+```
+
+This ensures PHPStan focuses only on your custom code.
+
+If you find that PHPStan needs to know about functions in third-party code, but you don't want it to analyse it, you can use the use the `excludePaths` and `analyse` parameters in your configuration:
+
+```neon
+parameters:
+	excludePaths:
+		analyse:
+			- path/to/files/to/not/analyse
+			- path/to/more/files/to/not/analyse
+```
+
+## PHPStan in VIP Projects
+
+When running PHPStan on a VIP based project, you'll want to make sure that PHPStan can scan the `mu-plugins` directory. Without this, you'll get errors regarding missing VIP functions.
+
+To scan the `mu-plugins` directory, you'll want to update your `phpstan.neon` to add `mu-plugins` to the `excludes_analyse` parameter:
+
+```neon
+parameters:
+	scanDirectories:
+		- mu-plugins
+```
+
+If you decide to run PHPStan on CircleCI, you're then likely see an error with it being unable to scan the `mu-plugins` directory.
+That's becuase the `mu-plugins` directory is git ignored and therefore doesn't exist in the CircleCI environment.
+
+To get around this, we can clone the MU plugins repo before we run PHPStan and then remove it again afterwards. This looks something like:
+
+```yaml
+version: 2
+jobs:
+  test:
+    docker:
+      - image: cimg/php:8.3-node
+    steps:
+      - checkout
+      - run:
+          name: Composer install
+          command: composer run setup
+      - run:
+          name: NPM install
+          command: npm install
+
+      # Your other build steps ...
+
+      - run:
+          name: Install VIP MU-Plugins
+          command: git clone git@github.com:Automattic/vip-go-mu-plugins.git --recursive mu-plugins/
+
+      - run:
+          name: Analyse PHP
+          command: composer run static
+
+      - run:
+          name: Remove VIP MU-Plugins
+          command: rm -rf mu-plugins/
+
+# The rest of your CircleCI config ...
+```
+
+With this in place, CircleCI should be able to run PHPStan properly again.

--- a/mu-plugins/10up-plugin/composer.json
+++ b/mu-plugins/10up-plugin/composer.json
@@ -1,5 +1,7 @@
 {
   "name": "10up/wp-plugin",
+  "description": "The starting point for all 10up WordPress plugins.",
+  "license": "MIT",
   "type": "wordpress-plugin",
   "authors": [
     {

--- a/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
+++ b/mu-plugins/10up-plugin/includes/classes/ModuleInitialization.php
@@ -78,7 +78,7 @@ class ModuleInitialization {
 			}
 
 			// Create a new reflection of the class.
-			// @phpstan-ignore-next-line
+			// @phpstan-ignore argument.type
 			$reflection_class = new ReflectionClass( $class );
 
 			// Using reflection, check if the class can be initialized.

--- a/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
+++ b/mu-plugins/10up-plugin/includes/classes/PostTypes/AbstractPostType.php
@@ -110,10 +110,47 @@ abstract class AbstractPostType extends Module {
 	/**
 	 * Get the options for the post type.
 	 *
-	 * @return array<mixed>
+	 * @return array{
+	 *      labels?: array<string, string>,
+	 *      description?: string,
+	 *      public?: bool,
+	 *      hierarchical?: bool,
+	 *      exclude_from_search?: bool,
+	 *      publicly_queryable?: bool,
+	 *      show_ui?: bool,
+	 *      show_in_menu?: bool,
+	 *      show_in_nav_menus?: bool,
+	 *      show_in_admin_bar?: bool,
+	 *      menu_position?: int,
+	 *      menu_icon?: string,
+	 *      capability_type?: string|array<int, string>,
+	 *      capabilities?: array<string, string>,
+	 *      map_meta_cap?: bool,
+	 *      supports?: array<string>|false,
+	 *      register_meta_box_cb?: callable,
+	 *      taxonomies?: array<string>,
+	 *      has_archive?: bool|string,
+	 *      rewrite?: bool|array{
+	 *          slug?: string,
+	 *          with_front?: bool,
+	 *          feeds?: bool,
+	 *          pages?: bool,
+	 *          ep_mask?: int,
+	 *      },
+	 *      query_var?: bool|string,
+	 *      can_export?: bool,
+	 *      delete_with_user?: bool,
+	 *      show_in_rest?: bool,
+	 *      rest_base?: string,
+	 *      rest_namespace?: string,
+	 *      rest_controller_class?: string,
+	 *      _builtin?: bool,
+	 *      template?: array<array<string, mixed>>,
+	 *      template_lock?: string|false,
+	 *  }
 	 */
 	public function get_options() {
-		return [
+		$options = [
 			'labels'            => $this->get_labels(),
 			'public'            => true,
 			'has_archive'       => true,
@@ -123,9 +160,16 @@ abstract class AbstractPostType extends Module {
 			'show_in_rest'      => true,
 			'supports'          => $this->get_editor_supports(),
 			'menu_icon'         => $this->get_menu_icon(),
-			'menu_position'     => $this->get_menu_position(),
 			'hierarchical'      => $this->is_hierarchical(),
 		];
+
+		$menu_position = $this->get_menu_position();
+
+		if ( null !== $menu_position ) {
+			$options['menu_position'] = $menu_position;
+		}
+
+		return $options;
 	}
 
 	/**

--- a/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
+++ b/mu-plugins/10up-plugin/includes/classes/Taxonomies/AbstractTaxonomy.php
@@ -95,7 +95,40 @@ abstract class AbstractTaxonomy extends Module {
 	/**
 	 * Get the options for the taxonomy.
 	 *
-	 * @return array<mixed>
+	 * @return array{
+	 *       labels?: array<string, string>,
+	 *       description?: string,
+	 *       public?: bool,
+	 *       publicly_queryable?: bool,
+	 *       hierarchical?: bool,
+	 *       show_ui?: bool,
+	 *       show_in_menu?: bool,
+	 *       show_in_nav_menus?: bool,
+	 *       show_tagcloud?: bool,
+	 *       show_in_quick_edit?: bool,
+	 *       show_admin_column?: bool,
+	 *       meta_box_cb?: bool|callable,
+	 *       show_in_rest?: bool,
+	 *       rest_base?: string,
+	 *       rest_namespace?: string,
+	 *       rest_controller_class?: string,
+	 *       capabilities?: array<string, string>,
+	 *       rewrite?: bool|array{
+	 *           slug?: string,
+	 *           with_front?: bool,
+	 *           hierarchical?: bool,
+	 *           ep_mask?: int,
+	 *       },
+	 *       query_var?: string|bool,
+	 *       update_count_callback?: callable,
+	 *       default_term?: string|array{
+	 *           name: string,
+	 *           slug?: string,
+	 *           description?: string,
+	 *       },
+	 *       sort?: bool,
+	 *       _builtin?: bool,
+	 *  }
 	 */
 	public function get_options() {
 		return [
@@ -112,7 +145,7 @@ abstract class AbstractTaxonomy extends Module {
 	/**
 	 * Get the labels for the taxonomy.
 	 *
-	 * @return array<string>
+	 * @return array<string, string>
 	 */
 	public function get_labels() {
 		$plural_label   = $this->get_plural_label();

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+includes:
+	- phpstan/default.neon
+
+parameters:
+	paths:
+		- themes/10up-theme
+		- mu-plugins/10up-plugin
+		- mu-plugins/10up-plugin-loader.php

--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * WP Constants used by PHPStan
+ *
+ * These should be updated to match constants that are set in any custom plugins or themes that will be anylised.
+ *
+ * @package TenUpPhpStan
+ */
+
+// Change these when you update the constants in the plugin.
+define( 'TENUP_PLUGIN_VERSION', '0.1.0' );
+define( 'TENUP_PLUGIN_URL', '' );
+define( 'TENUP_PLUGIN_PATH', '' );
+define( 'TENUP_PLUGIN_INC', TENUP_PLUGIN_PATH . 'includes/' );
+
+// Change these when you update the constants in the theme.
+define( 'TENUP_THEME_VERSION', '0.1.0' );
+define( 'TENUP_THEME_TEMPLATE_URL', '' );
+define( 'TENUP_THEME_PATH', '/' );
+define( 'TENUP_THEME_DIST_PATH', TENUP_THEME_PATH . 'dist/' );
+define( 'TENUP_THEME_DIST_URL', TENUP_THEME_TEMPLATE_URL . '/dist/' );
+define( 'TENUP_THEME_INC', TENUP_THEME_PATH . 'includes/' );
+define( 'TENUP_THEME_BLOCK_DIR', TENUP_THEME_INC . 'blocks/' );

--- a/phpstan/default.neon
+++ b/phpstan/default.neon
@@ -1,5 +1,6 @@
 includes:
 	- ../vendor/szepeviktor/phpstan-wordpress/extension.neon
+	- ../vendor/phpstan/phpstan-deprecation-rules/rules.neon
 
 parameters:
 	reportUnmatchedIgnoredErrors: false

--- a/phpstan/default.neon
+++ b/phpstan/default.neon
@@ -1,0 +1,31 @@
+includes:
+	- ../vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+parameters:
+	reportUnmatchedIgnoredErrors: false
+	level: 9
+	bootstrapFiles:
+		- constants.php
+	excludePaths:
+		analyseAndScan:
+			- ../../*/dist/*
+			- ../../*/node_modules/*
+			- ../../*/tests/*
+			- ./*
+		analyse:
+			- ../../*/vendor/*
+	scanDirectories:
+		- ../plugins
+	scanFiles:
+		- ../vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+		- ../vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
+		- ../vendor/php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php
+		- ../vendor/php-stubs/wp-cli-stubs/wp-cli-i18n-stubs.php
+	stubFiles:
+		- stubs/wp-query.stub
+	ignoreErrors:
+		# Uses func_get_args()
+		- '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'
+		- '#^Function remove_filter invoked with [34567] parameters, 2-3 required\.$#'
+		# Remove issues that come from using array as a type rather than string[] or array<string> etc.
+		- '#no value type specified in iterable type array#'

--- a/phpstan/stubs/wp-query.stub
+++ b/phpstan/stubs/wp-query.stub
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Whether current WordPress query has results to loop over.
+ *
+ * @since 1.5.0
+ *
+ * @global WP_Query $wp_query Global WP_Query instance.
+ *
+ * @return bool
+ * @phpstan-impure
+ */
+function have_posts()
+{
+}
+
+class WP_Query
+{
+    /**
+     * Determines whether there are more posts available in the loop.
+     *
+     * Calls the {@see 'loop_end'} action when the loop is complete.
+     *
+     * @since 1.5.0
+     *
+     * @return bool True if posts are available, false if end of loop.
+     * @phpstan-impure
+     */
+    public function have_posts()
+    {
+    }
+}

--- a/themes/10up-theme/composer.json
+++ b/themes/10up-theme/composer.json
@@ -1,5 +1,7 @@
 {
   "name": "10up/wp-theme",
+  "description": "The starting point for all 10up WordPress themes.",
+  "license": "MIT",
   "type": "wordpress-theme",
   "authors": [
     {

--- a/themes/10up-theme/includes/classes/ModuleInitialization.php
+++ b/themes/10up-theme/includes/classes/ModuleInitialization.php
@@ -79,7 +79,7 @@ class ModuleInitialization {
 			}
 
 			// Create a new reflection of the class.
-			// @phpstan-ignore-next-line
+			// @phpstan-ignore argument.type
 			$reflection_class = new ReflectionClass( $class );
 
 			// Using reflection, check if the class can be initialized.

--- a/themes/10up-theme/search.php
+++ b/themes/10up-theme/search.php
@@ -28,7 +28,7 @@ get_header(); ?>
 						the_post_thumbnail();
 					}
 
-					// @phpstan-ignore-next-lines
+					// @phpstan-ignore argument.type (s)
 					the_title( '<span itemprop="name"><a href="' . esc_url( get_permalink() ) . '" itemprop="url">', '</a></span>' );
 					?>
 					<div itemprop="description">


### PR DESCRIPTION
### Description of the Change
This PR enforces type quality within the scaffold by adding PHPStan and requiring it as a pre-merge check.

closes #133 

### How to test the Change
Check the PR action.

### Changelog Entry
* Added - PHPStan Checks to scaffold

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @darylldoyle @claytoncollie 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] ~I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.~
- [ ] All new and existing tests pass.
