### PR TITLE
Remove the script loader tag filter

### DIFF
--- a/mu-plugins/10up-plugin/src/Assets.php
+++ b/mu-plugins/10up-plugin/src/Assets.php
@@ -43,8 +43,6 @@ class Assets implements ModuleInterface {
 
 		// Editor styles. add_editor_style() doesn't work outside of a theme.
 		add_filter( 'mce_css', [ $this, 'mce_css' ] );
-		// Hook to allow async or defer on asset loading.
-		add_filter( 'script_loader_tag', [ $this, 'script_loader_tag' ], 10, 2 );
 	}
 
 	/**
@@ -208,41 +206,5 @@ class Assets implements ModuleInterface {
 		return $stylesheets . TENUP_PLUGIN_URL . ( ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ?
 				'assets/css/frontend/editor-style.css' :
 				'dist/css/editor-style.min.css' );
-	}
-
-	/**
-	 * Add async/defer attributes to enqueued scripts that have the specified script_execution flag.
-	 *
-	 * @link https://core.trac.wordpress.org/ticket/12009
-	 *
-	 * @param string $tag    The script tag.
-	 * @param string $handle The script handle.
-	 *
-	 * @return string|null
-	 */
-	public function script_loader_tag( $tag, $handle ) {
-		$script_execution = wp_scripts()->get_data( $handle, 'script_execution' );
-
-		if ( ! $script_execution ) {
-			return $tag;
-		}
-
-		if ( 'async' !== $script_execution && 'defer' !== $script_execution ) {
-			return $tag;
-		}
-
-		// Abort adding async/defer for scripts that have this script as a dependency. _doing_it_wrong()?
-		foreach ( wp_scripts()->registered as $script ) {
-			if ( in_array( $handle, $script->deps, true ) ) {
-				return $tag;
-			}
-		}
-
-		// Add the attribute if it hasn't already been added.
-		if ( ! preg_match( ":\s$script_execution(=|>|\s):", $tag ) ) {
-			$tag = preg_replace( ':(?=></script>):', " $script_execution", $tag, 1 );
-		}
-
-		return $tag;
 	}
 }

--- a/themes/10up-theme/src/Assets.php
+++ b/themes/10up-theme/src/Assets.php
@@ -43,8 +43,6 @@ class Assets implements ModuleInterface {
 		add_action( 'wp_enqueue_scripts', [ $this, 'styles' ] );
 		add_action( 'wp_head', [ $this, 'js_detection' ], 0 );
 		add_action( 'wp_head', [ $this, 'embed_ct_css' ], 0 );
-
-		add_filter( 'script_loader_tag', [ $this, 'script_loader_tag' ], 10, 2 );
 	}
 
 
@@ -171,40 +169,6 @@ class Assets implements ModuleInterface {
 	 */
 	public function js_detection() {
 		echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
-	}
-
-	/**
-	 * Add async/defer attributes to enqueued scripts that have the specified script_execution flag.
-	 *
-	 * @link https://core.trac.wordpress.org/ticket/12009
-	 * @param string $tag    The script tag.
-	 * @param string $handle The script handle.
-	 * @return string|null
-	 */
-	public function script_loader_tag( $tag, $handle ) {
-		$script_execution = wp_scripts()->get_data( $handle, 'script_execution' );
-
-		if ( ! $script_execution ) {
-			return $tag;
-		}
-
-		if ( 'async' !== $script_execution && 'defer' !== $script_execution ) {
-			return $tag;
-		}
-
-		// Abort adding async/defer for scripts that have this script as a dependency. _doing_it_wrong()?
-		foreach ( wp_scripts()->registered as $script ) {
-			if ( in_array( $handle, $script->deps, true ) ) {
-				return $tag;
-			}
-		}
-
-		// Add the attribute if it hasn't already been added.
-		if ( ! preg_match( ":\s$script_execution(=|>|\s):", $tag ) ) {
-			$tag = preg_replace( ':(?=></script>):', " $script_execution", $tag, 1 );
-		}
-
-		return $tag;
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
Remove the script loader tag. This functionality is built in WordPress core making this filter obsolete.

### Changelog Entry
> Removed - Script loader tag filter

### Credits
Props @claytoncollie 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
