### PR TITLE
Fix: blocks directory path in scaffold block command

### DIFF
--- a/themes/10up-block-theme/package.json
+++ b/themes/10up-block-theme/package.json
@@ -11,7 +11,7 @@
 		"lint-style": "10up-toolkit lint-style",
 		"test": "10up-toolkit test-unit-jest --passWithNoTests",
 		"clean-dist": "rm -rf ./dist",
-		"scaffold:block": "cd includes/blocks/ && wp-create-block --no-plugin --template ../../../../bin/create-block-template"
+		"scaffold:block": "cd blocks/ && wp-create-block --no-plugin --template ../../../../bin/create-block-template"
 	},
 	"engines": {
 		"node": ">=18.0.0"

--- a/themes/10up-theme/package.json
+++ b/themes/10up-theme/package.json
@@ -10,7 +10,7 @@
     "lint-style": "10up-toolkit lint-style",
     "test": "10up-toolkit test-unit-jest --passWithNoTests",
     "clean-dist": "rm -rf ./dist",
-    "scaffold:block": "cd includes/blocks/ && wp-create-block --no-plugin --template ../../../../bin/create-block-template"
+    "scaffold:block": "cd blocks/ && wp-create-block --no-plugin --template ../../../../bin/create-block-template"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
Follow up to the recent changes of moving the blocks dir top level