### PR TITLE
Feature: opt into loading separate block assets for new projects using classic themes

### DIFF
--- a/themes/10up-theme/src/Blocks.php
+++ b/themes/10up-theme/src/Blocks.php
@@ -44,6 +44,7 @@ class Blocks implements ModuleInterface {
 		add_action( 'init', [ $this, 'enqueue_block_specific_styles' ] );
 		add_action( 'init', [ $this, 'register_theme_blocks' ] );
 		add_action( 'init', [ $this, 'register_block_pattern_categories' ] );
+		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
This pull request includes a single change to the `register` function in the `themes/10up-theme/src/Blocks.php` file. The change adds a filter to ensure that separate core block assets are loaded.

* [`themes/10up-theme/src/Blocks.php`](diffhunk://#diff-9e1aa3892c317e74a21f26038dd386fd166553b14c18334e5147ea438d1bebefR47): Added `add_filter( 'should_load_separate_core_block_assets', '__return_true' );` to the `register` function, enabling the loading of separate core block assets.

[This feature was added all the way back in WordPress 5.8](https://make.wordpress.org/core/2021/07/01/block-styles-loading-enhancements-in-wordpress-5-8/) and is the default behavior for block themes. Adopting it on existing classic themes is a bit of a pain because it changes the loading order of individual block stylesheets which can cause issues. However when it is enabled by default for new builds we can architect and QA our styles for it from the beginning. 

When we do run into issues we now also have more fine grained controls over whether this behavior should only apply to our custom blocks or also to all core blocks. See the Dev Note for WordPress 6.8 here: https://make.wordpress.org/core/2025/03/24/new-filter-should_load_block_assets_on_demand-in-6-8/

Closes #134