### PR TITLE
Remove third-party block suggestions from the block inserter

### DIFF
--- a/themes/10up-block-theme/src/Blocks.php
+++ b/themes/10up-block-theme/src/Blocks.php
@@ -42,6 +42,9 @@ class Blocks implements ModuleInterface {
 		);
 		add_action( 'init', [ $this, 'register_theme_blocks' ], 10, 0 );
 		add_action( 'init', [ $this, 'enqueue_theme_block_styles' ], 10, 0 );
+
+		// Prevents third-party blocks from being suggested in the block inserter.
+		remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
 	}
 
 

--- a/themes/10up-theme/src/Blocks.php
+++ b/themes/10up-theme/src/Blocks.php
@@ -45,6 +45,9 @@ class Blocks implements ModuleInterface {
 		add_action( 'init', [ $this, 'register_theme_blocks' ] );
 		add_action( 'init', [ $this, 'register_block_pattern_categories' ] );
 		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
+
+		// Prevents third-party blocks from being suggested in the block inserter.
+		remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
Closes #267 by removing the third-party block suggestions from the block inserter. Also fixes the issue by removing the loading indicator when no blocks are found.

Closes #267 

<img width="579" height="587" alt="image" src="https://github.com/user-attachments/assets/d4773629-7ab3-4b64-8bc6-2c233a73f032" />


### How to test the Change
1. clone repo
2. composer install in all themes and plugins
3. npm install and npm run build
4. activate theme
5. create new page
6. open block inserter
7. type `none`
8. verify third-party blocks are not in the inserter panel
9. repeat for the block theme.

### Changelog Entry
> Added - removed third-party block suggestions from block inserter

### Credits
Props @claytoncollie @michael-sumner @fabiankaegy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
