### PR TITLE
Add explicit return type declarations to PHP methods for WP Framework compatibility

### DIFF
--- a/mu-plugins/10up-plugin/plugin.php
+++ b/mu-plugins/10up-plugin/plugin.php
@@ -16,6 +16,8 @@
  * @package           TenUpPlugin
  */
 
+declare( strict_types = 1 );
+
 // Useful global constants.
 define( 'TENUP_PLUGIN_VERSION', '0.1.0' );
 define( 'TENUP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/mu-plugins/10up-plugin/src/Assets.php
+++ b/mu-plugins/10up-plugin/src/Assets.php
@@ -26,7 +26,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return bool
 	 */
-	public function can_register() {
+	public function can_register(): bool {
 		return true;
 	}
 
@@ -35,7 +35,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function register() {
+	public function register(): void {
 		$this->setup_asset_vars(
 			dist_path: TENUP_PLUGIN_PATH . 'dist/',
 			fallback_version: TENUP_PLUGIN_VERSION
@@ -50,7 +50,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function admin_scripts() {
+	public function admin_scripts(): void {
 		wp_enqueue_script(
 			'tenup_plugin_admin',
 			TENUP_PLUGIN_URL . 'dist/js/admin.js',
@@ -65,7 +65,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function admin_styles() {
+	public function admin_styles(): void {
 		wp_enqueue_style(
 			'tenup_plugin_admin',
 			TENUP_PLUGIN_URL . 'dist/css/admin.css',

--- a/mu-plugins/10up-plugin/src/Assets.php
+++ b/mu-plugins/10up-plugin/src/Assets.php
@@ -5,6 +5,8 @@
  * @package TenUpPlugin
  */
 
+declare( strict_types = 1 );
+
 namespace TenUpPlugin;
 
 use TenupFramework\Assets\GetAssetInfo;

--- a/mu-plugins/10up-plugin/src/Core/Emoji.php
+++ b/mu-plugins/10up-plugin/src/Core/Emoji.php
@@ -5,6 +5,8 @@
  * @package TenUpPlugin/Core
  */
 
+declare( strict_types = 1 );
+
 namespace TenUpPlugin\Core;
 
 use TenupFramework\Module;

--- a/mu-plugins/10up-plugin/src/Core/HeadOverrides.php
+++ b/mu-plugins/10up-plugin/src/Core/HeadOverrides.php
@@ -5,6 +5,8 @@
  * @package TenUpPlugin/Core
  */
 
+declare( strict_types = 1 );
+
 namespace TenUpPlugin\Core;
 
 use TenupFramework\Module;

--- a/mu-plugins/10up-plugin/src/PluginCore.php
+++ b/mu-plugins/10up-plugin/src/PluginCore.php
@@ -5,6 +5,8 @@
  * @package TenUpPlugin
  */
 
+declare( strict_types = 1 );
+
 namespace TenUpPlugin;
 
 use TenupFramework\ModuleInitialization;

--- a/mu-plugins/10up-plugin/src/PostTypes/Demo.php
+++ b/mu-plugins/10up-plugin/src/PostTypes/Demo.php
@@ -19,7 +19,7 @@ class Demo extends AbstractPostType {
 	 *
 	 * @return string
 	 */
-	public function get_name() {
+	public function get_name(): string {
 		return 'tenup-demo';
 	}
 
@@ -28,7 +28,7 @@ class Demo extends AbstractPostType {
 	 *
 	 * @return string
 	 */
-	public function get_singular_label() {
+	public function get_singular_label(): string {
 		return esc_html__( 'Demo', 'tenup-plugin' );
 	}
 
@@ -37,7 +37,7 @@ class Demo extends AbstractPostType {
 	 *
 	 * @return string
 	 */
-	public function get_plural_label() {
+	public function get_plural_label(): string {
 		return esc_html__( 'Demos', 'tenup-plugin' );
 	}
 
@@ -50,7 +50,7 @@ class Demo extends AbstractPostType {
 	 *
 	 * @return string
 	 */
-	public function get_menu_icon() {
+	public function get_menu_icon(): string {
 		return 'dashicons-chart-pie';
 	}
 
@@ -59,7 +59,7 @@ class Demo extends AbstractPostType {
 	 *
 	 * @return bool
 	 */
-	public function can_register() {
+	public function can_register(): bool {
 		return false;
 	}
 
@@ -69,7 +69,7 @@ class Demo extends AbstractPostType {
 	 *
 	 * @return array<string>
 	 */
-	public function get_supported_taxonomies() {
+	public function get_supported_taxonomies(): array {
 		return [
 			'tenup-tax-demo',
 		];
@@ -80,7 +80,7 @@ class Demo extends AbstractPostType {
 	 *
 	 * @return void
 	 */
-	public function after_register() {
+	public function after_register(): void {
 		// Register any hooks/filters you need.
 	}
 }

--- a/mu-plugins/10up-plugin/src/PostTypes/Demo.php
+++ b/mu-plugins/10up-plugin/src/PostTypes/Demo.php
@@ -5,6 +5,8 @@
  * @package TenUpPlugin
  */
 
+declare( strict_types = 1 );
+
 namespace TenUpPlugin\PostTypes;
 
 use TenupFramework\PostTypes\AbstractPostType;

--- a/mu-plugins/10up-plugin/src/PostTypes/Page.php
+++ b/mu-plugins/10up-plugin/src/PostTypes/Page.php
@@ -5,6 +5,8 @@
  * @package TenUpPlugin
  */
 
+declare( strict_types = 1 );
+
 namespace TenUpPlugin\PostTypes;
 
 use TenupFramework\PostTypes\AbstractCorePostType;

--- a/mu-plugins/10up-plugin/src/PostTypes/Page.php
+++ b/mu-plugins/10up-plugin/src/PostTypes/Page.php
@@ -22,7 +22,7 @@ class Page extends AbstractCorePostType {
 	 *
 	 * @return string
 	 */
-	public function get_name() {
+	public function get_name(): string {
 		return 'page';
 	}
 
@@ -32,7 +32,7 @@ class Page extends AbstractCorePostType {
 	 *
 	 * @return array<string>
 	 */
-	public function get_supported_taxonomies() {
+	public function get_supported_taxonomies(): array {
 		return [];
 	}
 
@@ -41,7 +41,7 @@ class Page extends AbstractCorePostType {
 	 *
 	 * @return void
 	 */
-	public function after_register() {
+	public function after_register(): void {
 		// Do nothing.
 	}
 }

--- a/mu-plugins/10up-plugin/src/PostTypes/Post.php
+++ b/mu-plugins/10up-plugin/src/PostTypes/Post.php
@@ -5,6 +5,8 @@
  * @package TenUpPlugin
  */
 
+declare( strict_types = 1 );
+
 namespace TenUpPlugin\PostTypes;
 
 use TenupFramework\PostTypes\AbstractCorePostType;

--- a/mu-plugins/10up-plugin/src/PostTypes/Post.php
+++ b/mu-plugins/10up-plugin/src/PostTypes/Post.php
@@ -22,7 +22,7 @@ class Post extends AbstractCorePostType {
 	 *
 	 * @return string
 	 */
-	public function get_name() {
+	public function get_name(): string {
 		return 'post';
 	}
 
@@ -34,7 +34,7 @@ class Post extends AbstractCorePostType {
 	 *
 	 * @return array<string>
 	 */
-	public function get_supported_taxonomies() {
+	public function get_supported_taxonomies(): array {
 		return [];
 	}
 
@@ -43,7 +43,7 @@ class Post extends AbstractCorePostType {
 	 *
 	 * @return void
 	 */
-	public function after_register() {
+	public function after_register(): void {
 		// Do nothing.
 	}
 }

--- a/mu-plugins/10up-plugin/src/Taxonomies/Demo.php
+++ b/mu-plugins/10up-plugin/src/Taxonomies/Demo.php
@@ -19,7 +19,7 @@ class Demo extends AbstractTaxonomy {
 	 *
 	 * @return string
 	 */
-	public function get_name() {
+	public function get_name(): string {
 		return 'tenup-tax-demo';
 	}
 
@@ -28,7 +28,7 @@ class Demo extends AbstractTaxonomy {
 	 *
 	 * @return string
 	 */
-	public function get_singular_label() {
+	public function get_singular_label(): string {
 		return esc_html__( 'Demo Term', 'tenup-plugin' );
 	}
 
@@ -37,7 +37,7 @@ class Demo extends AbstractTaxonomy {
 	 *
 	 * @return string
 	 */
-	public function get_plural_label() {
+	public function get_plural_label(): string {
 		return esc_html__( 'Demo Terms', 'tenup-plugin' );
 	}
 
@@ -46,7 +46,7 @@ class Demo extends AbstractTaxonomy {
 	 *
 	 * @return bool
 	 */
-	public function can_register() {
+	public function can_register(): bool {
 		return false;
 	}
 }

--- a/mu-plugins/10up-plugin/src/Taxonomies/Demo.php
+++ b/mu-plugins/10up-plugin/src/Taxonomies/Demo.php
@@ -5,6 +5,8 @@
  * @package TenUpPlugin
  */
 
+declare( strict_types = 1 );
+
 namespace TenUpPlugin\Taxonomies;
 
 use TenupFramework\Taxonomies\AbstractTaxonomy;

--- a/themes/10up-block-theme/src/Assets.php
+++ b/themes/10up-block-theme/src/Assets.php
@@ -26,7 +26,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return bool
 	 */
-	public function can_register() {
+	public function can_register(): bool {
 		return true;
 	}
 
@@ -35,7 +35,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function register() {
+	public function register(): void {
 		$this->setup_asset_vars(
 			dist_path: TENUP_BLOCK_THEME_DIST_PATH,
 			fallback_version: TENUP_BLOCK_THEME_VERSION
@@ -51,7 +51,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function enqueue_frontend_assets() {
+	public function enqueue_frontend_assets(): void {
 		wp_enqueue_style(
 			'tenup-theme-styles',
 			TENUP_BLOCK_THEME_TEMPLATE_URL . '/dist/css/frontend.css',
@@ -77,7 +77,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function enqueue_block_editor_assets() {
+	public function enqueue_block_editor_assets(): void {
 		wp_enqueue_style(
 			'tenup-theme-editor-frame-style-overrides',
 			TENUP_BLOCK_THEME_TEMPLATE_URL . '/dist/css/editor-frame-style-overrides.css',
@@ -99,7 +99,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function enqueue_block_editor_iframe_assets() {
+	public function enqueue_block_editor_iframe_assets(): void {
 
 		// The `enqueue_block_assets` action is triggered both on the front-end and in the editor iframe.
 		// We only want to enqueue these styles inside the editor iframe.
@@ -120,7 +120,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function register_all_icons() {
+	public function register_all_icons(): void {
 		if ( ! function_exists( '\UIKitCore\Helpers\register_icons' ) ) {
 			return;
 		}

--- a/themes/10up-block-theme/src/Assets.php
+++ b/themes/10up-block-theme/src/Assets.php
@@ -5,6 +5,8 @@
  * @package TenupBlockTheme
  */
 
+declare( strict_types = 1 );
+
 namespace TenupBlockTheme;
 
 use TenupFramework\Assets\GetAssetInfo;

--- a/themes/10up-block-theme/src/Blocks.php
+++ b/themes/10up-block-theme/src/Blocks.php
@@ -5,6 +5,8 @@
  * @package TenupBlockTheme
  */
 
+declare( strict_types = 1 );
+
 namespace TenupBlockTheme;
 
 use TenupFramework\Assets\GetAssetInfo;

--- a/themes/10up-block-theme/src/Blocks.php
+++ b/themes/10up-block-theme/src/Blocks.php
@@ -26,7 +26,7 @@ class Blocks implements ModuleInterface {
 	 *
 	 * @return bool
 	 */
-	public function can_register() {
+	public function can_register(): bool {
 		return true;
 	}
 
@@ -35,7 +35,7 @@ class Blocks implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function register() {
+	public function register(): void {
 		$this->setup_asset_vars(
 			dist_path: TENUP_BLOCK_THEME_DIST_PATH,
 			fallback_version: TENUP_BLOCK_THEME_VERSION
@@ -53,7 +53,7 @@ class Blocks implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function register_theme_blocks() {
+	public function register_theme_blocks(): void {
 		// Register all the blocks in the theme.
 		if ( file_exists( TENUP_BLOCK_THEME_BLOCK_DIST_DIR ) ) {
 			$block_json_files = glob( TENUP_BLOCK_THEME_BLOCK_DIST_DIR . '*/block.json' );
@@ -91,7 +91,7 @@ class Blocks implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function enqueue_theme_block_styles() {
+	public function enqueue_theme_block_styles(): void {
 		$stylesheets = glob( TENUP_BLOCK_THEME_DIST_PATH . '/blocks/autoenqueue/**/*.css' );
 
 		if ( empty( $stylesheets ) ) {

--- a/themes/10up-block-theme/src/TemplateTags.php
+++ b/themes/10up-block-theme/src/TemplateTags.php
@@ -5,6 +5,8 @@
  * @package TenupBlockTheme
  */
 
+declare( strict_types = 1 );
+
 namespace TenupBlockTheme;
 
 use TenupFramework\Module;

--- a/themes/10up-block-theme/src/TemplateTags.php
+++ b/themes/10up-block-theme/src/TemplateTags.php
@@ -24,7 +24,7 @@ class TemplateTags implements ModuleInterface {
 	 *
 	 * @return bool
 	 */
-	public function can_register() {
+	public function can_register(): bool {
 		return true;
 	}
 
@@ -33,7 +33,7 @@ class TemplateTags implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function register() {
+	public function register(): void {
 		add_action( 'wp_head', [ $this, 'add_viewport_meta_tag' ], 10, 0 );
 	}
 
@@ -42,7 +42,7 @@ class TemplateTags implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function add_viewport_meta_tag() {
+	public function add_viewport_meta_tag(): void {
 		?>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 		<?php

--- a/themes/10up-block-theme/src/ThemeCore.php
+++ b/themes/10up-block-theme/src/ThemeCore.php
@@ -5,6 +5,8 @@
  * @package TenupBlockTheme
  */
 
+declare( strict_types = 1 );
+
 namespace TenupBlockTheme;
 
 use TenupFramework\ModuleInitialization;

--- a/themes/10up-theme/src/Assets.php
+++ b/themes/10up-theme/src/Assets.php
@@ -26,7 +26,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return bool
 	 */
-	public function can_register() {
+	public function can_register(): bool {
 		return true;
 	}
 
@@ -35,7 +35,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function register() {
+	public function register(): void {
 		$this->setup_asset_vars(
 			dist_path: TENUP_THEME_DIST_PATH,
 			fallback_version: TENUP_THEME_VERSION
@@ -51,7 +51,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function scripts() {
+	public function scripts(): void {
 		/**
 		 * Enqueuing frontend.js is required to get css hot reloading working in the frontend
 		 * If you're not shipping any front-end js wrap this enqueue in a SCRIPT_DEBUG check.
@@ -70,7 +70,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function enqueue_block_editor_scripts() {
+	public function enqueue_block_editor_scripts(): void {
 		wp_enqueue_script(
 			'block-editor-script',
 			TENUP_THEME_DIST_URL . 'js/block-editor-script.js',
@@ -85,7 +85,7 @@ class Assets implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function styles() {
+	public function styles(): void {
 		wp_enqueue_style(
 			'styles',
 			TENUP_THEME_TEMPLATE_URL . '/dist/css/frontend.css',

--- a/themes/10up-theme/src/Assets.php
+++ b/themes/10up-theme/src/Assets.php
@@ -5,6 +5,8 @@
  * @package TenUpTheme
  */
 
+declare( strict_types = 1 );
+
 namespace TenUpTheme;
 
 use TenupFramework\Assets\GetAssetInfo;

--- a/themes/10up-theme/src/Blocks.php
+++ b/themes/10up-theme/src/Blocks.php
@@ -5,6 +5,8 @@
  * @package TenUpTheme
  */
 
+declare( strict_types = 1 );
+
 namespace TenUpTheme;
 
 use TenupFramework\Assets\GetAssetInfo;

--- a/themes/10up-theme/src/Blocks.php
+++ b/themes/10up-theme/src/Blocks.php
@@ -26,7 +26,7 @@ class Blocks implements ModuleInterface {
 	 *
 	 * @return bool
 	 */
-	public function can_register() {
+	public function can_register(): bool {
 		return true;
 	}
 
@@ -35,7 +35,7 @@ class Blocks implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function register() {
+	public function register(): void {
 		$this->setup_asset_vars(
 			dist_path: TENUP_THEME_DIST_PATH,
 			fallback_version: TENUP_THEME_VERSION
@@ -55,7 +55,7 @@ class Blocks implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function register_theme_blocks() {
+	public function register_theme_blocks(): void {
 		// Register all the blocks in the theme
 		if ( file_exists( TENUP_THEME_BLOCK_DIST_DIR ) ) {
 			$block_json_files = glob( TENUP_THEME_BLOCK_DIST_DIR . '*/block.json' );
@@ -97,7 +97,7 @@ class Blocks implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function blocks_editor_styles() {
+	public function blocks_editor_styles(): void {
 		wp_enqueue_style(
 			'editor-style-overrides',
 			TENUP_THEME_TEMPLATE_URL . '/dist/css/editor-style-overrides.css',
@@ -132,7 +132,7 @@ class Blocks implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function enqueue_block_specific_styles() {
+	public function enqueue_block_specific_styles(): void {
 		$stylesheets = glob( TENUP_THEME_DIST_PATH . 'blocks/autoenqueue/**/*.css' );
 
 		if ( empty( $stylesheets ) ) {
@@ -179,7 +179,7 @@ class Blocks implements ModuleInterface {
 	 *
 	 * @return void
 	 */
-	public function register_block_pattern_categories() {
+	public function register_block_pattern_categories(): void {
 		// Register a block pattern category
 		register_block_pattern_category(
 			'10up-theme',

--- a/themes/10up-theme/src/ThemeCore.php
+++ b/themes/10up-theme/src/ThemeCore.php
@@ -5,6 +5,8 @@
  * @package TenUpTheme
  */
 
+declare( strict_types = 1 );
+
 namespace TenUpTheme;
 
 use TenupFramework\ModuleInitialization;


### PR DESCRIPTION
**Requires `wp-framework` 2.0.0 / develop**

### Description of the Change

Add explicit return type declarations to PHP methods for WP Framework compatibility
Adds strict types to all PHP classes

Closes #

### How to test the Change

1. Create a site using the WP Scaffold
2. Run `composer install; npm install; npm run build` for:
  - The MU plugin: `mu-plugins/10up-plugin`
  - The 10up theme: `themes/10up-theme`
  - The 10up block theme: `themes/10up-block-theme`
 3. Confirm there is no fatal error in WP Admin
 4. Activate the 10up theme; confirm no fatal errors
 5. Activate the 10up block theme; confirm no fatal errors

### Changelog Entry

> Added: explicit return type declarations to PHP methods for WP Framework compatibility

### Credits
Props @jamesmorrison 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
