### PR TITLE
Feature: Add Scaffold Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,50 @@ It contains a bare bones theme and must use plugin for you to base your developm
 
 ## How to Use
 
-_The best way to use the scaffold is to simply run `npx 10up-toolkit project init` in your terminal._
+### Quick Start (Recommended)
 
-You can also use the scaffold manually by doing the following:
+The fastest way to get started is to run the scaffold CLI. It walks you through a few questions, then renames every placeholder string, directory, config reference, and translation file in the project so it matches your new project name.
+
+1. Clone or download the scaffold into your `wp-content` directory.
+2. Install dependencies:
+
+```bash
+npm install
+```
+
+3. Run the scaffold:
+
+```bash
+npm run scaffold
+```
+
+The CLI will ask you to choose a hosting platform (Standard or VIP), a theme type (Block or Classic), and a project name. It then derives all the namespaces, constants, slugs, text domains, and other naming conventions from the project name automatically. You can accept the defaults or customize each value individually.
+
+When it finishes, the unused theme is deleted, all placeholder strings are replaced, directories are renamed, and lock files are cleaned up so you can start fresh.
+
+#### Non-interactive mode
+
+If you already know what you want, you can pass everything as flags and skip the prompts entirely:
+
+```bash
+npm run scaffold -- \
+  --project-name "Acme Corp" \
+  --theme block \
+  --hosting standard \
+  --author-name "Acme Inc" \
+  --description "The Acme Corp website" \
+  --yes
+```
+
+Run `npm run scaffold -- --help` to see all available options, including individual overrides for plugin/theme slugs, namespaces, constants, and metadata.
+
+#### Self-destruct
+
+By default the script will ask whether you want to remove it after scaffolding is complete. You can also pass the `--self-destruct` flag to do this automatically. When enabled, the script removes the `bin/scaffold.mjs` file, the `scaffold` npm script, and the `@inquirer/prompts` dependency from `package.json`.
+
+### Manual Setup
+
+You can also set up the scaffold manually without the CLI:
 
 1. [Download a zip](https://github.com/10up/wp-scaffold/archive/trunk.zip) of the repository into your project. At 10up, by default we version control the `wp-content` directory (ignoring obvious things like `uploads`). This enables us to have plugins, theme, etc. all in one repository. Having separate repositories for each plugin and theme only happens in rare circumstances that are outside of our control.
 2. Take what you need. If your project doesn't have a theme, remove the theme. If your project doesn't need any plugin functionality, remove the MU plugin. If your plugin doesn't need CSS/JS, remove it. If your plugin doesn't need to be translated, remove all the translation functionality.
@@ -38,8 +79,8 @@ You can also use the scaffold manually by doing the following:
 	"watch": "run-s watch:theme watch:plugin",
 ```
 
-7. To add npm dependencies to your theme and/or plugins add the `-w=package-name` flag to the `npm install` command. E.g: `npm install --save prop-types -w=tenup-plugin` **DO NOT RUN** `npm install` inside an individual workspace/package. Always run the from the root folder.
-8. If you're building Gutenberg blocks and importing `@wordpress/*` packages, **you do not** need to manually install them as `10up-toolkit` will handle these packages properly.
+8. To add npm dependencies to your theme and/or plugins add the `-w=package-name` flag to the `npm install` command. E.g: `npm install --save prop-types -w=tenup-plugin` **DO NOT RUN** `npm install` inside an individual workspace/package. Always run the from the root folder.
+9. If you're building Gutenberg blocks and importing `@wordpress/*` packages, **you do not** need to manually install them as `10up-toolkit` will handle these packages properly.
 
 ## Scaffold Rules
 

--- a/bin/scaffold.mjs
+++ b/bin/scaffold.mjs
@@ -21,6 +21,7 @@ import {
 	mkdirSync,
 } from 'node:fs';
 import { join, resolve, extname } from 'node:path';
+import { parseArgs } from 'node:util';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -136,36 +137,144 @@ function walkFiles(dir, results = []) {
 }
 
 // ---------------------------------------------------------------------------
-// Main
+// CLI argument parsing
 // ---------------------------------------------------------------------------
 
+const CLI_OPTIONS = {
+	// Core
+	hosting: { type: 'string', short: 'h' },
+	theme: { type: 'string', short: 't' },
+	'project-name': { type: 'string', short: 'n' },
+
+	// Plugin
+	'plugin-slug': { type: 'string' },
+	'plugin-namespace': { type: 'string' },
+	'plugin-constant': { type: 'string' },
+	'plugin-text-domain': { type: 'string' },
+	'plugin-hook-prefix': { type: 'string' },
+	'plugin-human-name': { type: 'string' },
+	'plugin-npm-name': { type: 'string' },
+
+	// Theme
+	'theme-slug': { type: 'string' },
+	'theme-namespace': { type: 'string' },
+	'theme-constant': { type: 'string' },
+	'theme-text-domain': { type: 'string' },
+	'theme-hook-prefix': { type: 'string' },
+	'theme-human-name': { type: 'string' },
+	'theme-npm-name': { type: 'string' },
+
+	// Metadata
+	'author-name': { type: 'string' },
+	'author-email': { type: 'string' },
+	'author-uri': { type: 'string' },
+	description: { type: 'string' },
+	'composer-vendor': { type: 'string' },
+	'homepage-url': { type: 'string' },
+	'repo-url': { type: 'string' },
+
+	// Flags
+	yes: { type: 'boolean', short: 'y', default: false },
+	help: { type: 'boolean', default: false },
+};
+
+function printHelp() {
+	console.log(`
+  Usage: npm run scaffold -- [options]
+
+  Options:
+    -n, --project-name <name>       Project name (e.g. "Acme Corp")
+    -h, --hosting <type>            Hosting platform: "standard" or "vip"
+    -t, --theme <type>              Theme type: "block" or "classic"
+    -y, --yes                       Skip confirmation prompt
+
+  Plugin overrides:
+    --plugin-slug <slug>            Plugin directory and slug
+    --plugin-namespace <ns>         PHP namespace (e.g. AcmeCorpPlugin)
+    --plugin-constant <prefix>      Constant prefix (e.g. ACME_CORP_PLUGIN)
+    --plugin-text-domain <domain>   Text domain
+    --plugin-hook-prefix <prefix>   Hook prefix (e.g. acme_corp_plugin)
+    --plugin-human-name <name>      Human-readable name
+    --plugin-npm-name <name>        npm package name
+
+  Theme overrides:
+    --theme-slug <slug>             Theme directory and slug
+    --theme-namespace <ns>          PHP namespace (e.g. AcmeCorpTheme)
+    --theme-constant <prefix>       Constant prefix (e.g. ACME_CORP_THEME)
+    --theme-text-domain <domain>    Text domain
+    --theme-hook-prefix <prefix>    Hook prefix (e.g. acme_corp_theme)
+    --theme-human-name <name>       Human-readable name
+    --theme-npm-name <name>         npm package name
+
+  Metadata:
+    --author-name <name>            Author name
+    --author-email <email>          Author email
+    --author-uri <uri>              Author URI
+    --description <text>            Project description
+    --composer-vendor <vendor>      Composer vendor slug
+    --homepage-url <url>            Project homepage URL
+    --repo-url <url>                Repository URL
+
+  Examples:
+    npm run scaffold
+    npm run scaffold -- -n "Acme Corp" -t block -h standard -y
+    npm run scaffold -- --project-name "Acme Corp" --theme block --hosting vip --yes
+`);
+}
+
+function parseCli() {
+	try {
+		const { values } = parseArgs({ options: CLI_OPTIONS, strict: true });
+		return values;
+	} catch (err) {
+		console.error(`\n  Error: ${err.message}\n`);
+		printHelp();
+		process.exit(1);
+	}
+}
+
 async function main() {
+	const args = parseCli();
+
+	if (args.help) {
+		printHelp();
+		process.exit(0);
+	}
+
 	console.log('\n  WordPress Project Scaffold\n');
 
 	// -----------------------------------------------------------------------
-	// 1. Prompts
+	// 1. Prompts (skipped for any value provided via CLI flags)
 	// -----------------------------------------------------------------------
 
-	const hosting = await select({
-		message: 'What hosting platform will this project use?',
-		choices: [
-			{ name: 'Standard WordPress', value: 'standard' },
-			{ name: 'WordPress VIP', value: 'vip' },
-		],
-	});
+	const hosting =
+		args.hosting && ['standard', 'vip'].includes(args.hosting)
+			? args.hosting
+			: await select({
+					message: 'What hosting platform will this project use?',
+					choices: [
+						{ name: 'Standard WordPress', value: 'standard' },
+						{ name: 'WordPress VIP', value: 'vip' },
+					],
+				});
 
-	const themeType = await select({
-		message: 'Which theme type would you like to use?',
-		choices: [
-			{ name: 'Block Theme (Recommended)', value: 'block' },
-			{ name: 'Classic Theme', value: 'classic' },
-		],
-	});
+	const themeType =
+		args.theme && ['block', 'classic'].includes(args.theme)
+			? args.theme
+			: await select({
+					message: 'Which theme type would you like to use?',
+					choices: [
+						{ name: 'Block Theme (Recommended)', value: 'block' },
+						{ name: 'Classic Theme', value: 'classic' },
+					],
+				});
 
-	const projectName = await input({
-		message: 'Project name (human-readable, e.g. "Acme Corp"):',
-		validate: (v) => (v.trim().length > 0 ? true : 'Project name is required.'),
-	});
+	const projectName = args['project-name']
+		? args['project-name']
+		: await input({
+				message: 'Project name (human-readable, e.g. "Acme Corp"):',
+				validate: (v) => (v.trim().length > 0 ? true : 'Project name is required.'),
+			});
 
 	const isVip = hosting === 'vip';
 	const isBlock = themeType === 'block';
@@ -176,148 +285,164 @@ async function main() {
 	const gitOrg = getGitOrgFromUrl(gitRemoteUrl);
 
 	// -----------------------------------------------------------------------
-	// 2. Derive values
+	// 2. Derive values (CLI flags override auto-derived defaults)
 	// -----------------------------------------------------------------------
 
 	const defaults = {
 		// Plugin
-		pluginSlug: `${slug}-plugin`,
-		pluginNamespace: `${toPascal(slug)}Plugin`,
-		pluginConstant: `${toConstant(slug)}_PLUGIN`,
-		pluginTextDomain: `${slug}-plugin`,
-		pluginHookPrefix: `${toSnake(slug)}_plugin`,
-		pluginHumanName: `${toTitle(slug)} Plugin`,
-		pluginNpmName: `${slug}-plugin`,
+		pluginSlug: args['plugin-slug'] || `${slug}-plugin`,
+		pluginNamespace: args['plugin-namespace'] || `${toPascal(slug)}Plugin`,
+		pluginConstant: args['plugin-constant'] || `${toConstant(slug)}_PLUGIN`,
+		pluginTextDomain: args['plugin-text-domain'] || `${slug}-plugin`,
+		pluginHookPrefix: args['plugin-hook-prefix'] || `${toSnake(slug)}_plugin`,
+		pluginHumanName: args['plugin-human-name'] || `${toTitle(slug)} Plugin`,
+		pluginNpmName: args['plugin-npm-name'] || `${slug}-plugin`,
 
 		// Theme
-		themeSlug: `${slug}-theme`,
-		themeNamespace: `${toPascal(slug)}Theme`,
-		themeConstant: `${toConstant(slug)}_THEME`,
-		themeTextDomain: `${slug}-theme`,
-		themeHookPrefix: `${toSnake(slug)}_theme`,
-		themeHumanName: `${toTitle(slug)} Theme`,
-		themeNpmName: `${slug}-theme`,
+		themeSlug: args['theme-slug'] || `${slug}-theme`,
+		themeNamespace: args['theme-namespace'] || `${toPascal(slug)}Theme`,
+		themeConstant: args['theme-constant'] || `${toConstant(slug)}_THEME`,
+		themeTextDomain: args['theme-text-domain'] || `${slug}-theme`,
+		themeHookPrefix: args['theme-hook-prefix'] || `${toSnake(slug)}_theme`,
+		themeHumanName: args['theme-human-name'] || `${toTitle(slug)} Theme`,
+		themeNpmName: args['theme-npm-name'] || `${slug}-theme`,
 
 		// Metadata
-		authorName: '',
-		authorEmail: '',
-		authorUri: '',
-		description: '',
-		composerVendor: gitOrg || slug,
-		homepageUrl: '',
-		repoUrl: gitRemoteUrl || '',
+		authorName: args['author-name'] || '',
+		authorEmail: args['author-email'] || '',
+		authorUri: args['author-uri'] || '',
+		description: args.description || '',
+		composerVendor: args['composer-vendor'] || gitOrg || slug,
+		homepageUrl: args['homepage-url'] || '',
+		repoUrl: args['repo-url'] || gitRemoteUrl || '',
 	};
+
+	// Determine if we are running fully non-interactive (all three required
+	// flags were provided via CLI). When non-interactive, skip customization
+	// and metadata prompts entirely, using defaults for anything not provided.
+	const isNonInteractive = args['project-name'] && args.hosting && args.theme;
 
 	// -----------------------------------------------------------------------
 	// 3. Show summary and allow customization
 	// -----------------------------------------------------------------------
 
-	console.log('\n  Derived values:\n');
-	console.log(`  Plugin directory:     ${defaults.pluginSlug}`);
-	console.log(`  Plugin namespace:     ${defaults.pluginNamespace}`);
-	console.log(`  Plugin constants:     ${defaults.pluginConstant}_*`);
-	console.log(`  Plugin text domain:   ${defaults.pluginTextDomain}`);
-	console.log(`  Plugin human name:    ${defaults.pluginHumanName}`);
-	console.log('');
-	console.log(`  Theme directory:      ${defaults.themeSlug}`);
-	console.log(`  Theme namespace:      ${defaults.themeNamespace}`);
-	console.log(`  Theme constants:      ${defaults.themeConstant}_*`);
-	console.log(`  Theme text domain:    ${defaults.themeTextDomain}`);
-	console.log(`  Theme human name:     ${defaults.themeHumanName}`);
-	console.log('');
-	console.log(`  Composer vendor:      ${defaults.composerVendor}`);
-	if (defaults.repoUrl) {
-		console.log(`  Repository URL:       ${defaults.repoUrl}`);
-	}
-	console.log('');
-
-	const customize = await select({
-		message: 'How would you like to proceed?',
-		choices: [
-			{ name: 'Accept all derived values and continue to metadata', value: 'accept' },
-			{ name: 'Customize each value individually', value: 'customize' },
-		],
-	});
-
 	const values = { ...defaults };
 
-	if (customize === 'customize') {
-		console.log('\n  Plugin configuration:\n');
-		values.pluginSlug = await input({
-			message: 'Plugin slug / directory:',
-			default: defaults.pluginSlug,
-		});
-		values.pluginNamespace = await input({
-			message: 'Plugin PHP namespace:',
-			default: defaults.pluginNamespace,
-		});
-		values.pluginConstant = await input({
-			message: 'Plugin constant prefix:',
-			default: defaults.pluginConstant,
-		});
-		values.pluginTextDomain = await input({
-			message: 'Plugin text domain:',
-			default: defaults.pluginTextDomain,
-		});
-		values.pluginHookPrefix = await input({
-			message: 'Plugin hook prefix:',
-			default: defaults.pluginHookPrefix,
-		});
-		values.pluginHumanName = await input({
-			message: 'Plugin human name:',
-			default: defaults.pluginHumanName,
-		});
-		values.pluginNpmName = await input({
-			message: 'Plugin npm package name:',
-			default: defaults.pluginNpmName,
+	if (!isNonInteractive) {
+		console.log('\n  Derived values:\n');
+		console.log(`  Plugin directory:     ${defaults.pluginSlug}`);
+		console.log(`  Plugin namespace:     ${defaults.pluginNamespace}`);
+		console.log(`  Plugin constants:     ${defaults.pluginConstant}_*`);
+		console.log(`  Plugin text domain:   ${defaults.pluginTextDomain}`);
+		console.log(`  Plugin human name:    ${defaults.pluginHumanName}`);
+		console.log('');
+		console.log(`  Theme directory:      ${defaults.themeSlug}`);
+		console.log(`  Theme namespace:      ${defaults.themeNamespace}`);
+		console.log(`  Theme constants:      ${defaults.themeConstant}_*`);
+		console.log(`  Theme text domain:    ${defaults.themeTextDomain}`);
+		console.log(`  Theme human name:     ${defaults.themeHumanName}`);
+		console.log('');
+		console.log(`  Composer vendor:      ${defaults.composerVendor}`);
+		if (defaults.repoUrl) {
+			console.log(`  Repository URL:       ${defaults.repoUrl}`);
+		}
+		console.log('');
+
+		const customize = await select({
+			message: 'How would you like to proceed?',
+			choices: [
+				{ name: 'Accept all derived values and continue to metadata', value: 'accept' },
+				{ name: 'Customize each value individually', value: 'customize' },
+			],
 		});
 
-		console.log('\n  Theme configuration:\n');
-		values.themeSlug = await input({
-			message: 'Theme slug / directory:',
-			default: defaults.themeSlug,
+		if (customize === 'customize') {
+			console.log('\n  Plugin configuration:\n');
+			values.pluginSlug = await input({
+				message: 'Plugin slug / directory:',
+				default: defaults.pluginSlug,
+			});
+			values.pluginNamespace = await input({
+				message: 'Plugin PHP namespace:',
+				default: defaults.pluginNamespace,
+			});
+			values.pluginConstant = await input({
+				message: 'Plugin constant prefix:',
+				default: defaults.pluginConstant,
+			});
+			values.pluginTextDomain = await input({
+				message: 'Plugin text domain:',
+				default: defaults.pluginTextDomain,
+			});
+			values.pluginHookPrefix = await input({
+				message: 'Plugin hook prefix:',
+				default: defaults.pluginHookPrefix,
+			});
+			values.pluginHumanName = await input({
+				message: 'Plugin human name:',
+				default: defaults.pluginHumanName,
+			});
+			values.pluginNpmName = await input({
+				message: 'Plugin npm package name:',
+				default: defaults.pluginNpmName,
+			});
+
+			console.log('\n  Theme configuration:\n');
+			values.themeSlug = await input({
+				message: 'Theme slug / directory:',
+				default: defaults.themeSlug,
+			});
+			values.themeNamespace = await input({
+				message: 'Theme PHP namespace:',
+				default: defaults.themeNamespace,
+			});
+			values.themeConstant = await input({
+				message: 'Theme constant prefix:',
+				default: defaults.themeConstant,
+			});
+			values.themeTextDomain = await input({
+				message: 'Theme text domain:',
+				default: defaults.themeTextDomain,
+			});
+			values.themeHookPrefix = await input({
+				message: 'Theme hook prefix:',
+				default: defaults.themeHookPrefix,
+			});
+			values.themeHumanName = await input({
+				message: 'Theme human name:',
+				default: defaults.themeHumanName,
+			});
+			values.themeNpmName = await input({
+				message: 'Theme npm package name:',
+				default: defaults.themeNpmName,
+			});
+		}
+
+		// Prompt for metadata
+		console.log('\n  Project metadata:\n');
+		values.authorName = await input({
+			message: 'Author name:',
+			default: defaults.authorName,
 		});
-		values.themeNamespace = await input({
-			message: 'Theme PHP namespace:',
-			default: defaults.themeNamespace,
+		values.authorEmail = await input({
+			message: 'Author email:',
+			default: defaults.authorEmail,
 		});
-		values.themeConstant = await input({
-			message: 'Theme constant prefix:',
-			default: defaults.themeConstant,
+		values.authorUri = await input({ message: 'Author URI:', default: defaults.authorUri });
+		values.description = await input({
+			message: 'Project description:',
+			default: defaults.description,
 		});
-		values.themeTextDomain = await input({
-			message: 'Theme text domain:',
-			default: defaults.themeTextDomain,
+		values.composerVendor = await input({
+			message: 'Composer vendor slug:',
+			default: defaults.composerVendor,
 		});
-		values.themeHookPrefix = await input({
-			message: 'Theme hook prefix:',
-			default: defaults.themeHookPrefix,
+		values.homepageUrl = await input({
+			message: 'Homepage URL:',
+			default: defaults.homepageUrl,
 		});
-		values.themeHumanName = await input({
-			message: 'Theme human name:',
-			default: defaults.themeHumanName,
-		});
-		values.themeNpmName = await input({
-			message: 'Theme npm package name:',
-			default: defaults.themeNpmName,
-		});
+		values.repoUrl = await input({ message: 'Repository URL:', default: defaults.repoUrl });
 	}
-
-	// Always prompt for metadata
-	console.log('\n  Project metadata:\n');
-	values.authorName = await input({ message: 'Author name:', default: defaults.authorName });
-	values.authorEmail = await input({ message: 'Author email:', default: defaults.authorEmail });
-	values.authorUri = await input({ message: 'Author URI:', default: defaults.authorUri });
-	values.description = await input({
-		message: 'Project description:',
-		default: defaults.description,
-	});
-	values.composerVendor = await input({
-		message: 'Composer vendor slug:',
-		default: defaults.composerVendor,
-	});
-	values.homepageUrl = await input({ message: 'Homepage URL:', default: defaults.homepageUrl });
-	values.repoUrl = await input({ message: 'Repository URL:', default: defaults.repoUrl });
 
 	// -----------------------------------------------------------------------
 	// 4. Confirm
@@ -334,10 +459,12 @@ async function main() {
 
 	const muDir = isVip ? 'client-mu-plugins' : 'mu-plugins';
 
-	const ok = await confirm({ message: 'Apply these changes?', default: true });
-	if (!ok) {
-		console.log('\n  Aborted. No changes were made.\n');
-		process.exit(0);
+	if (!args.yes) {
+		const ok = await confirm({ message: 'Apply these changes?', default: true });
+		if (!ok) {
+			console.log('\n  Aborted. No changes were made.\n');
+			process.exit(0);
+		}
 	}
 
 	// -----------------------------------------------------------------------

--- a/bin/scaffold.mjs
+++ b/bin/scaffold.mjs
@@ -1,0 +1,718 @@
+#!/usr/bin/env node
+
+/**
+ * WordPress Project Scaffold CLI
+ *
+ * Interactive CLI script that renames all placeholder strings, directories,
+ * and config references in the 10up wp-scaffold starter to match a new project.
+ *
+ * Run with: npm run scaffold
+ */
+
+import { select, input, confirm } from '@inquirer/prompts';
+import { execSync } from 'node:child_process';
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	writeFileSync,
+	renameSync,
+	rmSync,
+	mkdirSync,
+} from 'node:fs';
+import { join, resolve, extname } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+const BINARY_EXTENSIONS = new Set([
+	'.png',
+	'.jpg',
+	'.jpeg',
+	'.gif',
+	'.webp',
+	'.ico',
+	'.svg',
+	'.woff',
+	'.woff2',
+	'.eot',
+	'.ttf',
+	'.otf',
+	'.zip',
+	'.gz',
+	'.tar',
+	'.bz2',
+	'.mp4',
+	'.mp3',
+	'.mov',
+	'.avi',
+	'.pdf',
+	'.doc',
+	'.docx',
+	'.lock',
+]);
+
+const SKIP_DIRS = new Set(['node_modules', 'vendor', '.git', 'plugins']);
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+/** Convert "Acme Corp" to "acme-corp" */
+function toKebab(name) {
+	return name
+		.replace(/([a-z])([A-Z])/g, '$1-$2')
+		.replace(/[\s_]+/g, '-')
+		.replace(/[^a-z0-9-]/gi, '')
+		.toLowerCase();
+}
+
+/** Convert "acme-corp" to "AcmeCorp" */
+function toPascal(slug) {
+	return slug
+		.split('-')
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+		.join('');
+}
+
+/** Convert "acme-corp" to "ACME_CORP" */
+function toConstant(slug) {
+	return slug.replace(/-/g, '_').toUpperCase();
+}
+
+/** Convert "acme-corp" to "acme_corp" */
+function toSnake(slug) {
+	return slug.replace(/-/g, '_');
+}
+
+/** Convert "acme-corp" to "Acme Corp" */
+function toTitle(slug) {
+	return slug
+		.split('-')
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+		.join(' ');
+}
+
+/** Try to read the git remote origin URL */
+function getGitRemoteUrl() {
+	try {
+		const url = execSync('git remote get-url origin', { cwd: ROOT, encoding: 'utf-8' }).trim();
+		// Normalize git@github.com:org/repo.git to https://github.com/org/repo
+		if (url.startsWith('git@')) {
+			return url.replace(/^git@([^:]+):/, 'https://$1/').replace(/\.git$/, '');
+		}
+		return url.replace(/\.git$/, '');
+	} catch {
+		return '';
+	}
+}
+
+/** Extract the org/user from a GitHub URL */
+function getGitOrgFromUrl(url) {
+	const match = url.match(/github\.com\/([^/]+)/);
+	return match ? match[1].toLowerCase() : '';
+}
+
+// ---------------------------------------------------------------------------
+// File-walking helpers
+// ---------------------------------------------------------------------------
+
+function walkFiles(dir, results = []) {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const fullPath = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (SKIP_DIRS.has(entry.name)) continue;
+			walkFiles(fullPath, results);
+		} else if (entry.isFile()) {
+			if (BINARY_EXTENSIONS.has(extname(entry.name).toLowerCase())) continue;
+			if (entry.name === 'package-lock.json') continue;
+			results.push(fullPath);
+		}
+	}
+	return results;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+	console.log('\n  WordPress Project Scaffold\n');
+
+	// -----------------------------------------------------------------------
+	// 1. Prompts
+	// -----------------------------------------------------------------------
+
+	const hosting = await select({
+		message: 'What hosting platform will this project use?',
+		choices: [
+			{ name: 'Standard WordPress', value: 'standard' },
+			{ name: 'WordPress VIP', value: 'vip' },
+		],
+	});
+
+	const themeType = await select({
+		message: 'Which theme type would you like to use?',
+		choices: [
+			{ name: 'Block Theme (Recommended)', value: 'block' },
+			{ name: 'Classic Theme', value: 'classic' },
+		],
+	});
+
+	const projectName = await input({
+		message: 'Project name (human-readable, e.g. "Acme Corp"):',
+		validate: (v) => (v.trim().length > 0 ? true : 'Project name is required.'),
+	});
+
+	const isVip = hosting === 'vip';
+	const isBlock = themeType === 'block';
+	const slug = toKebab(projectName.trim());
+
+	// Auto-detect git remote
+	const gitRemoteUrl = getGitRemoteUrl();
+	const gitOrg = getGitOrgFromUrl(gitRemoteUrl);
+
+	// -----------------------------------------------------------------------
+	// 2. Derive values
+	// -----------------------------------------------------------------------
+
+	const defaults = {
+		// Plugin
+		pluginSlug: `${slug}-plugin`,
+		pluginNamespace: `${toPascal(slug)}Plugin`,
+		pluginConstant: `${toConstant(slug)}_PLUGIN`,
+		pluginTextDomain: `${slug}-plugin`,
+		pluginHookPrefix: `${toSnake(slug)}_plugin`,
+		pluginHumanName: `${toTitle(slug)} Plugin`,
+		pluginNpmName: `${slug}-plugin`,
+
+		// Theme
+		themeSlug: `${slug}-theme`,
+		themeNamespace: `${toPascal(slug)}Theme`,
+		themeConstant: `${toConstant(slug)}_THEME`,
+		themeTextDomain: `${slug}-theme`,
+		themeHookPrefix: `${toSnake(slug)}_theme`,
+		themeHumanName: `${toTitle(slug)} Theme`,
+		themeNpmName: `${slug}-theme`,
+
+		// Metadata
+		authorName: '',
+		authorEmail: '',
+		authorUri: '',
+		description: '',
+		composerVendor: gitOrg || slug,
+		homepageUrl: '',
+		repoUrl: gitRemoteUrl || '',
+	};
+
+	// -----------------------------------------------------------------------
+	// 3. Show summary and allow customization
+	// -----------------------------------------------------------------------
+
+	console.log('\n  Derived values:\n');
+	console.log(`  Plugin directory:     ${defaults.pluginSlug}`);
+	console.log(`  Plugin namespace:     ${defaults.pluginNamespace}`);
+	console.log(`  Plugin constants:     ${defaults.pluginConstant}_*`);
+	console.log(`  Plugin text domain:   ${defaults.pluginTextDomain}`);
+	console.log(`  Plugin human name:    ${defaults.pluginHumanName}`);
+	console.log('');
+	console.log(`  Theme directory:      ${defaults.themeSlug}`);
+	console.log(`  Theme namespace:      ${defaults.themeNamespace}`);
+	console.log(`  Theme constants:      ${defaults.themeConstant}_*`);
+	console.log(`  Theme text domain:    ${defaults.themeTextDomain}`);
+	console.log(`  Theme human name:     ${defaults.themeHumanName}`);
+	console.log('');
+	console.log(`  Composer vendor:      ${defaults.composerVendor}`);
+	if (defaults.repoUrl) {
+		console.log(`  Repository URL:       ${defaults.repoUrl}`);
+	}
+	console.log('');
+
+	const customize = await select({
+		message: 'How would you like to proceed?',
+		choices: [
+			{ name: 'Accept all derived values and continue to metadata', value: 'accept' },
+			{ name: 'Customize each value individually', value: 'customize' },
+		],
+	});
+
+	const values = { ...defaults };
+
+	if (customize === 'customize') {
+		console.log('\n  Plugin configuration:\n');
+		values.pluginSlug = await input({
+			message: 'Plugin slug / directory:',
+			default: defaults.pluginSlug,
+		});
+		values.pluginNamespace = await input({
+			message: 'Plugin PHP namespace:',
+			default: defaults.pluginNamespace,
+		});
+		values.pluginConstant = await input({
+			message: 'Plugin constant prefix:',
+			default: defaults.pluginConstant,
+		});
+		values.pluginTextDomain = await input({
+			message: 'Plugin text domain:',
+			default: defaults.pluginTextDomain,
+		});
+		values.pluginHookPrefix = await input({
+			message: 'Plugin hook prefix:',
+			default: defaults.pluginHookPrefix,
+		});
+		values.pluginHumanName = await input({
+			message: 'Plugin human name:',
+			default: defaults.pluginHumanName,
+		});
+		values.pluginNpmName = await input({
+			message: 'Plugin npm package name:',
+			default: defaults.pluginNpmName,
+		});
+
+		console.log('\n  Theme configuration:\n');
+		values.themeSlug = await input({
+			message: 'Theme slug / directory:',
+			default: defaults.themeSlug,
+		});
+		values.themeNamespace = await input({
+			message: 'Theme PHP namespace:',
+			default: defaults.themeNamespace,
+		});
+		values.themeConstant = await input({
+			message: 'Theme constant prefix:',
+			default: defaults.themeConstant,
+		});
+		values.themeTextDomain = await input({
+			message: 'Theme text domain:',
+			default: defaults.themeTextDomain,
+		});
+		values.themeHookPrefix = await input({
+			message: 'Theme hook prefix:',
+			default: defaults.themeHookPrefix,
+		});
+		values.themeHumanName = await input({
+			message: 'Theme human name:',
+			default: defaults.themeHumanName,
+		});
+		values.themeNpmName = await input({
+			message: 'Theme npm package name:',
+			default: defaults.themeNpmName,
+		});
+	}
+
+	// Always prompt for metadata
+	console.log('\n  Project metadata:\n');
+	values.authorName = await input({ message: 'Author name:', default: defaults.authorName });
+	values.authorEmail = await input({ message: 'Author email:', default: defaults.authorEmail });
+	values.authorUri = await input({ message: 'Author URI:', default: defaults.authorUri });
+	values.description = await input({
+		message: 'Project description:',
+		default: defaults.description,
+	});
+	values.composerVendor = await input({
+		message: 'Composer vendor slug:',
+		default: defaults.composerVendor,
+	});
+	values.homepageUrl = await input({ message: 'Homepage URL:', default: defaults.homepageUrl });
+	values.repoUrl = await input({ message: 'Repository URL:', default: defaults.repoUrl });
+
+	// -----------------------------------------------------------------------
+	// 4. Confirm
+	// -----------------------------------------------------------------------
+
+	console.log('\n  Summary of changes:\n');
+	console.log(`  Hosting:              ${isVip ? 'WordPress VIP' : 'Standard WordPress'}`);
+	console.log(`  Theme type:           ${isBlock ? 'Block Theme' : 'Classic Theme'}`);
+	console.log(`  Plugin:               ${values.pluginSlug} (${values.pluginNamespace})`);
+	console.log(`  Theme:                ${values.themeSlug} (${values.themeNamespace})`);
+	if (values.authorName) console.log(`  Author:               ${values.authorName}`);
+	if (values.repoUrl) console.log(`  Repository:           ${values.repoUrl}`);
+	console.log('');
+
+	const muDir = isVip ? 'client-mu-plugins' : 'mu-plugins';
+
+	const ok = await confirm({ message: 'Apply these changes?', default: true });
+	if (!ok) {
+		console.log('\n  Aborted. No changes were made.\n');
+		process.exit(0);
+	}
+
+	// -----------------------------------------------------------------------
+	// 5. Execute changes
+	// -----------------------------------------------------------------------
+
+	console.log('\n  Applying changes...\n');
+
+	// -- Step 1: Delete unused theme --
+	const themeToDelete = isBlock ? 'themes/10up-theme' : 'themes/10up-block-theme';
+	const themeToDeletePath = join(ROOT, themeToDelete);
+	if (existsSync(themeToDeletePath)) {
+		rmSync(themeToDeletePath, { recursive: true, force: true });
+		console.log(`  Deleted ${themeToDelete}/`);
+	}
+
+	// -- Step 2: Move plugin to client-mu-plugins (VIP) --
+	if (isVip) {
+		const clientMuDir = join(ROOT, 'client-mu-plugins');
+		if (!existsSync(clientMuDir)) {
+			mkdirSync(clientMuDir, { recursive: true });
+		}
+
+		// Move plugin directory
+		const oldPluginDir = join(ROOT, 'mu-plugins', '10up-plugin');
+		const newPluginDir = join(clientMuDir, '10up-plugin');
+		if (existsSync(oldPluginDir)) {
+			renameSync(oldPluginDir, newPluginDir);
+			console.log('  Moved mu-plugins/10up-plugin/ -> client-mu-plugins/10up-plugin/');
+		}
+
+		// Move loader file
+		const oldLoader = join(ROOT, 'mu-plugins', '10up-plugin-loader.php');
+		const newLoader = join(clientMuDir, '10up-plugin-loader.php');
+		if (existsSync(oldLoader)) {
+			renameSync(oldLoader, newLoader);
+			console.log(
+				'  Moved mu-plugins/10up-plugin-loader.php -> client-mu-plugins/10up-plugin-loader.php',
+			);
+		}
+
+		// Clean up empty mu-plugins dir if it's now empty
+		const muPluginsDir = join(ROOT, 'mu-plugins');
+		if (existsSync(muPluginsDir)) {
+			const remaining = readdirSync(muPluginsDir);
+			if (remaining.length === 0) {
+				rmSync(muPluginsDir, { recursive: true, force: true });
+			}
+		}
+	}
+
+	// -- Step 3: Pre-replacement cleanup --
+	// Remove the deleted theme's entries from config files BEFORE string
+	// replacements run. This prevents duplicate constants (both theme constant
+	// sets would otherwise be renamed to the same prefix).
+
+	// 3a: phpstan.neon - remove deleted theme path lines
+	const phpstanPath = join(ROOT, 'phpstan.neon');
+	if (existsSync(phpstanPath)) {
+		let phpstanContent = readFileSync(phpstanPath, 'utf-8');
+		// Remove any path line referencing a directory that no longer exists.
+		const lines = phpstanContent.split('\n');
+		phpstanContent = lines
+			.filter((line) => {
+				const trimmed = line.trim();
+				if (trimmed.startsWith('- ')) {
+					const path = trimmed.slice(2).trim();
+					const fullPath = join(ROOT, path);
+					if (!existsSync(fullPath)) return false;
+				}
+				return true;
+			})
+			.join('\n');
+		writeFileSync(phpstanPath, phpstanContent);
+		console.log('  Cleaned phpstan.neon paths');
+	}
+
+	// 3b: phpstan/constants.php - remove the deleted theme's constant block
+	const phpstanConstantsPath = join(ROOT, 'phpstan', 'constants.php');
+	if (existsSync(phpstanConstantsPath)) {
+		let constContent = readFileSync(phpstanConstantsPath, 'utf-8');
+
+		if (isBlock) {
+			// Keep TENUP_BLOCK_THEME_* (will be renamed by replacements).
+			// Remove TENUP_THEME_* but NOT lines that also match TENUP_BLOCK_THEME_.
+			constContent = constContent
+				.split('\n')
+				.filter((line) => {
+					if (line.includes('TENUP_BLOCK_THEME_')) return true;
+					if (line.includes('TENUP_THEME_')) return false;
+					return true;
+				})
+				.join('\n');
+		} else {
+			// Keep TENUP_THEME_* (will be renamed by replacements).
+			// Remove TENUP_BLOCK_THEME_*.
+			constContent = constContent
+				.split('\n')
+				.filter((line) => {
+					return !line.includes('TENUP_BLOCK_THEME_');
+				})
+				.join('\n');
+		}
+
+		constContent = constContent.replace(/\n{3,}/g, '\n\n');
+		writeFileSync(phpstanConstantsPath, constContent);
+		console.log('  Cleaned phpstan/constants.php');
+	}
+
+	// -- Step 4: Build replacement map --
+	// Order: longest match first to avoid partial matches.
+	// Also include path prefix replacements for VIP.
+
+	const replacements = [];
+
+	// Theme replacements (chosen theme)
+	if (isBlock) {
+		// The block theme uses both "tenup-block-theme" (directory/style.css) AND
+		// "tenup-theme" (internal handles, text domain, pattern slugs). We need
+		// to replace both. Longer strings first to avoid partial matches.
+		replacements.push(
+			['TenUpBlockTheme', values.themeNamespace],
+			['TenupBlockTheme', values.themeNamespace],
+			['TENUP_BLOCK_THEME', values.themeConstant],
+			['tenup-block-theme', values.themeSlug],
+			['tenup_block_theme', values.themeHookPrefix],
+			['10up-block-theme', values.themeSlug],
+			['10up Block Theme', values.themeHumanName],
+			['TenUpTheme', values.themeNamespace],
+			['TENUP_THEME', values.themeConstant],
+			['tenup-theme', values.themeNpmName],
+			['tenup_theme', values.themeHookPrefix],
+			['10up-theme', values.themeSlug],
+			['10up Theme', values.themeHumanName],
+		);
+	} else {
+		replacements.push(
+			['TenUpTheme', values.themeNamespace],
+			['TENUP_THEME', values.themeConstant],
+			['tenup-theme', values.themeSlug],
+			['tenup_theme', values.themeHookPrefix],
+			['10up-theme', values.themeSlug],
+			['10up Theme', values.themeHumanName],
+		);
+	}
+
+	// Plugin replacements
+	replacements.push(
+		['TenUpPlugin', values.pluginNamespace],
+		['TENUP_PLUGIN', values.pluginConstant],
+		['tenup-plugin', values.pluginSlug],
+		['tenup_plugin', values.pluginHookPrefix],
+		['10up-plugin', values.pluginSlug],
+		['10up Plugin Scaffold', values.pluginHumanName],
+	);
+
+	// VIP: mu-plugins -> client-mu-plugins path replacement.
+	// Use targeted patterns to avoid changing generic "mu-plugins" WordPress references.
+	if (isVip) {
+		replacements.push(
+			['mu-plugins/10up-plugin', 'client-mu-plugins/10up-plugin'],
+			['<file>mu-plugins</file>', '<file>client-mu-plugins</file>'],
+		);
+	}
+
+	// Composer package names
+	replacements.push(
+		['10up/wp-scaffold', `${values.composerVendor}/${slug}`],
+		['10up/wp-plugin', `${values.composerVendor}/${values.pluginSlug}`],
+		['10up/wp-theme', `${values.composerVendor}/${values.themeSlug}`],
+		['10up/tenup-theme', `${values.composerVendor}/${values.themeSlug}`],
+	);
+
+	// npm root package name
+	replacements.push(['tenup-wp-scaffold', slug]);
+
+	// Author / metadata
+	if (values.authorEmail) {
+		replacements.push(['info@10up.com', values.authorEmail]);
+	}
+	if (values.authorUri) {
+		replacements.push(['https://10up.com', values.authorUri]);
+	}
+
+	// Description strings (longer matches first)
+	if (values.description) {
+		replacements.push(
+			['The starting point for all 10up WordPress projects.', values.description],
+			['The starting point for all 10up WordPress themes.', values.description],
+			['The starting point for all 10up WordPress plugins.', values.description],
+			['A brief description of the plugin.', values.description],
+			['Project description.', values.description],
+			['Project Description', values.description],
+		);
+	}
+
+	// URLs
+	if (values.repoUrl) {
+		replacements.push(
+			['https://github.com/10up/wp-scaffold', values.repoUrl],
+			['https://project-git-repo.tld', values.repoUrl],
+		);
+	}
+	if (values.homepageUrl) {
+		replacements.push(['https://project-domain.tld', values.homepageUrl]);
+	}
+
+	// Author name replacement (must be last / most targeted to avoid over-matching).
+	// We only replace the exact author patterns to avoid mangling things like
+	// "10up-toolkit" or "10up/phpcs-composer".
+	if (values.authorName) {
+		replacements.push(
+			['"name": "10up"', `"name": "${values.authorName}"`],
+			['Author:            10up', `Author:            ${values.authorName}`],
+			['Author:      10up', `Author:      ${values.authorName}`],
+			['Author:        10up', `Author:        ${values.authorName}`],
+		);
+	}
+
+	// Sort by length of search string descending to prevent partial matches.
+	replacements.sort((a, b) => b[0].length - a[0].length);
+
+	// -- Step 4: Apply string replacements across all files --
+	const files = walkFiles(ROOT);
+	let filesChanged = 0;
+
+	for (const filePath of files) {
+		// Skip the scaffold script itself
+		if (filePath === resolve(ROOT, 'bin', 'scaffold.mjs')) continue;
+
+		let content;
+		try {
+			content = readFileSync(filePath, 'utf-8');
+		} catch {
+			continue;
+		}
+
+		let updated = content;
+
+		for (const [search, replace] of replacements) {
+			if (updated.includes(search)) {
+				updated = updated.replaceAll(search, replace);
+			}
+		}
+
+		if (updated !== content) {
+			writeFileSync(filePath, updated);
+			filesChanged++;
+		}
+	}
+	console.log(`  Updated strings in ${filesChanged} files`);
+
+	// -- Step 6: Directory and file renames --
+
+	// Rename plugin directory
+	const currentPluginParent = isVip ? join(ROOT, 'client-mu-plugins') : join(ROOT, 'mu-plugins');
+	const oldPluginDirName = join(currentPluginParent, '10up-plugin');
+	const newPluginDirName = join(currentPluginParent, values.pluginSlug);
+	if (existsSync(oldPluginDirName) && oldPluginDirName !== newPluginDirName) {
+		renameSync(oldPluginDirName, newPluginDirName);
+		console.log(`  Renamed plugin directory to ${values.pluginSlug}/`);
+	}
+
+	// Rename theme directory
+	const oldThemeDirName = isBlock
+		? join(ROOT, 'themes', '10up-block-theme')
+		: join(ROOT, 'themes', '10up-theme');
+	const newThemeDirName = join(ROOT, 'themes', values.themeSlug);
+	if (existsSync(oldThemeDirName) && oldThemeDirName !== newThemeDirName) {
+		renameSync(oldThemeDirName, newThemeDirName);
+		console.log(`  Renamed theme directory to ${values.themeSlug}/`);
+	}
+
+	// Rename loader file
+	const oldLoaderName = join(currentPluginParent, '10up-plugin-loader.php');
+	const newLoaderName = join(currentPluginParent, `${values.pluginSlug}-loader.php`);
+	if (existsSync(oldLoaderName) && oldLoaderName !== newLoaderName) {
+		renameSync(oldLoaderName, newLoaderName);
+		console.log(`  Renamed loader to ${values.pluginSlug}-loader.php`);
+	}
+
+	// Rename .pot files
+	const pluginPotOld = join(newPluginDirName, 'languages', 'TenUpPlugin.pot');
+	const pluginPotNew = join(newPluginDirName, 'languages', `${values.pluginNamespace}.pot`);
+	if (existsSync(pluginPotOld) && pluginPotOld !== pluginPotNew) {
+		renameSync(pluginPotOld, pluginPotNew);
+		console.log(`  Renamed TenUpPlugin.pot to ${values.pluginNamespace}.pot`);
+	}
+
+	if (!isBlock) {
+		const themePotOld = join(newThemeDirName, 'languages', 'TenUpTheme.pot');
+		const themePotNew = join(newThemeDirName, 'languages', `${values.themeNamespace}.pot`);
+		if (existsSync(themePotOld) && themePotOld !== themePotNew) {
+			renameSync(themePotOld, themePotNew);
+			console.log(`  Renamed TenUpTheme.pot to ${values.themeNamespace}.pot`);
+		}
+	}
+
+	// -- Step 7: Post-rename fixups --
+	// Fix globalStylesDir/globalMixinsDir in plugin package.json.
+	// After rename, the plugin is at its new location. The path references
+	// "10up-theme" which may not have been caught if block theme was chosen.
+	const renamedPluginPkg = join(newPluginDirName, 'package.json');
+	if (existsSync(renamedPluginPkg)) {
+		let pluginPkgContent = readFileSync(renamedPluginPkg, 'utf-8');
+		// Replace any remaining old theme directory references in paths
+		if (isBlock) {
+			pluginPkgContent = pluginPkgContent.replaceAll('10up-theme', values.themeSlug);
+			pluginPkgContent = pluginPkgContent.replaceAll('10up-block-theme', values.themeSlug);
+		} else {
+			pluginPkgContent = pluginPkgContent.replaceAll('10up-theme', values.themeSlug);
+		}
+		writeFileSync(renamedPluginPkg, pluginPkgContent);
+	}
+
+	// Fix the loader file content to point to the renamed directory.
+	// The loader file does: require_once __DIR__ . '/10up-plugin/plugin.php';
+	// After string replacement, "10up-plugin" was already replaced, but double check.
+	if (existsSync(newLoaderName)) {
+		let loaderContent = readFileSync(newLoaderName, 'utf-8');
+		loaderContent = loaderContent.replaceAll('10up-plugin', values.pluginSlug);
+		writeFileSync(newLoaderName, loaderContent);
+	}
+
+	// -- Step 8: Cleanup --
+
+	// Delete package-lock.json
+	const lockPath = join(ROOT, 'package-lock.json');
+	if (existsSync(lockPath)) {
+		rmSync(lockPath);
+		console.log('  Deleted package-lock.json');
+	}
+
+	// Delete composer.lock files
+	for (const lockFile of [
+		join(ROOT, 'composer.lock'),
+		join(newPluginDirName, 'composer.lock'),
+		join(newThemeDirName, 'composer.lock'),
+	]) {
+		if (existsSync(lockFile)) {
+			rmSync(lockFile);
+			console.log(`  Deleted ${lockFile.replace(`${ROOT}/`, '')}`);
+		}
+	}
+
+	// Remove scaffold-related entries from package.json
+	const rootPkgPath = join(ROOT, 'package.json');
+	if (existsSync(rootPkgPath)) {
+		const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf-8'));
+		if (rootPkg.scripts?.scaffold) {
+			delete rootPkg.scripts.scaffold;
+		}
+		if (rootPkg.devDependencies?.['@inquirer/prompts']) {
+			delete rootPkg.devDependencies['@inquirer/prompts'];
+		}
+		writeFileSync(rootPkgPath, `${JSON.stringify(rootPkg, null, '  ')}\n`);
+		console.log('  Removed scaffold script and @inquirer/prompts from package.json');
+	}
+
+	// -- Done! --
+	console.log('\n  Done! Your project has been scaffolded.\n');
+	console.log('  Next steps:\n');
+	console.log('    1. Run npm install');
+	console.log(
+		`    2. Run composer install in the root, ${muDir}/${values.pluginSlug}, and themes/${values.themeSlug}`,
+	);
+	console.log('    3. Run npm run build');
+	console.log('');
+}
+
+main().catch((err) => {
+	if (err.name === 'ExitPromptError') {
+		console.log('\n  Aborted.\n');
+		process.exit(0);
+	}
+	console.error(err);
+	process.exit(1);
+});

--- a/bin/scaffold.mjs
+++ b/bin/scaffold.mjs
@@ -175,6 +175,7 @@ const CLI_OPTIONS = {
 
 	// Flags
 	yes: { type: 'boolean', short: 'y', default: false },
+	'self-destruct': { type: 'boolean', default: false },
 	help: { type: 'boolean', default: false },
 };
 
@@ -187,6 +188,7 @@ function printHelp() {
     -h, --hosting <type>            Hosting platform: "standard" or "vip"
     -t, --theme <type>              Theme type: "block" or "classic"
     -y, --yes                       Skip confirmation prompt
+    --self-destruct                 Remove the scaffold script and bin/ directory after running
 
   Plugin overrides:
     --plugin-slug <slug>            Plugin directory and slug
@@ -218,7 +220,7 @@ function printHelp() {
   Examples:
     npm run scaffold
     npm run scaffold -- -n "Acme Corp" -t block -h standard -y
-    npm run scaffold -- --project-name "Acme Corp" --theme block --hosting vip --yes
+    npm run scaffold -- --project-name "Acme Corp" --theme block --hosting vip --yes --self-destruct
 `);
 }
 
@@ -458,6 +460,15 @@ async function main() {
 	console.log('');
 
 	const muDir = isVip ? 'client-mu-plugins' : 'mu-plugins';
+
+	// Determine whether to remove the scaffold script after running.
+	let selfDestruct = args['self-destruct'] === true;
+	if (!selfDestruct && !isNonInteractive) {
+		selfDestruct = await confirm({
+			message: 'Remove the scaffold script and its dependencies after running?',
+			default: true,
+		});
+	}
 
 	if (!args.yes) {
 		const ok = await confirm({ message: 'Apply these changes?', default: true });
@@ -810,18 +821,34 @@ async function main() {
 		}
 	}
 
-	// Remove scaffold-related entries from package.json
-	const rootPkgPath = join(ROOT, 'package.json');
-	if (existsSync(rootPkgPath)) {
-		const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf-8'));
-		if (rootPkg.scripts?.scaffold) {
-			delete rootPkg.scripts.scaffold;
+	// -- Self-destruct: remove scaffold script and dependencies --
+	if (selfDestruct) {
+		const rootPkgPath = join(ROOT, 'package.json');
+		if (existsSync(rootPkgPath)) {
+			const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf-8'));
+			if (rootPkg.scripts?.scaffold) {
+				delete rootPkg.scripts.scaffold;
+			}
+			if (rootPkg.devDependencies?.['@inquirer/prompts']) {
+				delete rootPkg.devDependencies['@inquirer/prompts'];
+			}
+			writeFileSync(rootPkgPath, `${JSON.stringify(rootPkg, null, '  ')}\n`);
+			console.log('  Removed scaffold script and @inquirer/prompts from package.json');
 		}
-		if (rootPkg.devDependencies?.['@inquirer/prompts']) {
-			delete rootPkg.devDependencies['@inquirer/prompts'];
+
+		// Delete the scaffold script file
+		const scriptPath = resolve(ROOT, 'bin', 'scaffold.mjs');
+		if (existsSync(scriptPath)) {
+			rmSync(scriptPath);
+			console.log('  Deleted bin/scaffold.mjs');
 		}
-		writeFileSync(rootPkgPath, `${JSON.stringify(rootPkg, null, '  ')}\n`);
-		console.log('  Removed scaffold script and @inquirer/prompts from package.json');
+
+		// Remove the bin/ directory if it is now empty
+		const binDir = resolve(ROOT, 'bin');
+		if (existsSync(binDir) && readdirSync(binDir).length === 0) {
+			rmSync(binDir, { recursive: true });
+			console.log('  Deleted empty bin/ directory');
+		}
 	}
 
 	// -- Done! --

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Welcome to the documentation for the WP Scaffold! This is your starting point fo
 ## Table of Contents
 - [Getting Started](#getting-started)
 - [Installation](./installation.md)
+- [Scaffold CLI](./installation.md#running-the-scaffold-cli)
 - [Architecture Overview](./backend-development/architecture-overview.md)
 - [Contributing Guidelines](./contributing-community/contributing-guidelines.md)
 - [Troubleshooting Guide](./troubleshooting-faq/troubleshooting-guide.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,7 @@ This guide provides step-by-step instructions for installing and configuring a W
 - [Cloning the Repository](#cloning-the-repository)
 - [Setting Up with Local WP](#setting-up-with-local-wp)
 - [Installing Dependencies](#installing-dependencies)
+- [Running the Scaffold CLI](#running-the-scaffold-cli)
 - [Database Setup](#database-setup)
 - [Troubleshooting](#troubleshooting)
 
@@ -14,9 +15,10 @@ This guide provides step-by-step instructions for installing and configuring a W
 - Local WP (https://localwp.com/)
 - Git
 - Composer (for PHP dependencies)
-- Node.js & npm (for JS dependencies)
+- Node.js >= 20 and npm >= 9 (for JS dependencies)
 
 ## Cloning the Repository
+
 ```bash
 git clone <your-repo-url>
 ```
@@ -25,19 +27,111 @@ git clone <your-repo-url>
 1. Open Local WP and create a new site.
 2. Choose 'Custom' setup and set the site path to your cloned repository.
 3. Set PHP version, web server, and database as needed.
-4. Ensure the `wp-content` directory in Local WP points to your project’s `wp-content` folder.
+4. Ensure the `wp-content` directory in Local WP points to your project's `wp-content` folder.
 
 ## Installing Dependencies
+
 Open a terminal in the `wp-content` directory and run:
+
 ```bash
-composer install
 npm install
 ```
 
+## Running the Scaffold CLI
+
+Before you start developing, run the scaffold CLI to replace all placeholder names with your project's actual names. This is a one-time step that renames namespaces, constants, slugs, directories, config files, and translation files throughout the codebase.
+
+### Interactive mode
+
+```bash
+npm run scaffold
+```
+
+The CLI walks you through a series of prompts:
+
+1. **Hosting platform** - Standard WordPress or WordPress VIP. VIP projects move the mu-plugin into `client-mu-plugins/` instead of `mu-plugins/`.
+2. **Theme type** - Block Theme (recommended) or Classic Theme. The theme you do not choose is deleted.
+3. **Project name** - A human-readable name like "Acme Corp". All other naming conventions (slugs, namespaces, constants, text domains, hook prefixes) are derived from this automatically.
+4. **Customization** - You can accept all derived values or customize each one individually.
+5. **Metadata** - Author name, email, URI, project description, Composer vendor, homepage, and repository URL. The repository URL is auto-detected from your Git remote when available.
+6. **Self-destruct** - Whether to remove the scaffold script and its dependencies after running. This is recommended for production projects since the script is only needed once.
+
+### Non-interactive mode
+
+You can skip the prompts entirely by passing all required values as flags. This is useful for CI pipelines or when you already know exactly what you want:
+
+```bash
+npm run scaffold -- \
+  --project-name "Acme Corp" \
+  --theme block \
+  --hosting standard \
+  --yes \
+  --self-destruct
+```
+
+When the three required flags (`--project-name`, `--hosting`, `--theme`) are all provided, the script runs in fully non-interactive mode. It uses auto-derived defaults for any value you do not explicitly pass.
+
+### All available flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--project-name` | `-n` | Project name (e.g. "Acme Corp") |
+| `--hosting` | `-h` | Hosting platform: `standard` or `vip` |
+| `--theme` | `-t` | Theme type: `block` or `classic` |
+| `--yes` | `-y` | Skip the confirmation prompt |
+| `--self-destruct` | | Remove the scaffold script after running |
+| `--plugin-slug` | | Plugin directory and slug |
+| `--plugin-namespace` | | PHP namespace (e.g. AcmeCorpPlugin) |
+| `--plugin-constant` | | Constant prefix (e.g. ACME_CORP_PLUGIN) |
+| `--plugin-text-domain` | | Text domain |
+| `--plugin-hook-prefix` | | Hook prefix (e.g. acme_corp_plugin) |
+| `--plugin-human-name` | | Human-readable plugin name |
+| `--plugin-npm-name` | | npm package name |
+| `--theme-slug` | | Theme directory and slug |
+| `--theme-namespace` | | PHP namespace (e.g. AcmeCorpTheme) |
+| `--theme-constant` | | Constant prefix (e.g. ACME_CORP_THEME) |
+| `--theme-text-domain` | | Text domain |
+| `--theme-hook-prefix` | | Hook prefix (e.g. acme_corp_theme) |
+| `--theme-human-name` | | Human-readable theme name |
+| `--theme-npm-name` | | npm package name |
+| `--author-name` | | Author name |
+| `--author-email` | | Author email |
+| `--author-uri` | | Author URI |
+| `--description` | | Project description |
+| `--composer-vendor` | | Composer vendor slug |
+| `--homepage-url` | | Project homepage URL |
+| `--repo-url` | | Repository URL |
+
+### What the scaffold does
+
+When you run the script, it performs the following steps in order:
+
+1. Deletes the theme you did not choose (Block or Classic).
+2. For VIP projects, moves the mu-plugin and its loader into `client-mu-plugins/`.
+3. Cleans up PHPStan config and constants for the deleted theme.
+4. Walks every file in the project and replaces all placeholder strings (namespaces, constants, slugs, text domains, package names, URLs, author metadata).
+5. Renames the plugin and theme directories to match the new slugs.
+6. Renames translation `.pot` files to match the new text domains.
+7. Updates npm workspace paths and watch scripts in the root `package.json`.
+8. Deletes `package-lock.json` and `composer.lock` so you can regenerate them cleanly.
+9. Optionally removes the scaffold script itself (`--self-destruct`).
+
+### After scaffolding
+
+Once the scaffold completes, run the following to set up your project:
+
+```bash
+npm install
+composer install
+npm run build
+```
+
+You will also need to run `composer install` inside the mu-plugin and theme directories where `composer.json` files exist.
+
 ## Database Setup
 - Local WP will create a database for your site automatically.
-- If you have a database dump (e.g., `local.sql`), import it using Local WP’s database tools or via the command line.
-- Update your site’s settings in the WordPress admin as needed.
+- If you have a database dump (e.g., `local.sql`), import it using Local WP's database tools or via the command line.
+- Update your site's settings in the WordPress admin as needed.
 
 ## Troubleshooting
 If you encounter issues, see the [Troubleshooting Guide](./troubleshooting-faq/troubleshooting-guide.md) or check the logs in the `wp-content` directory if available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "10up-toolkit": "^6.5.0"
       },
       "devDependencies": {
+        "@inquirer/prompts": "^7.0.0",
         "@wordpress/create-block": "4.55.0",
         "husky": "^9.1.7",
         "lint-staged": "^15.2.0",
@@ -195,7 +196,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -226,7 +226,6 @@
       "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.0.tgz",
       "integrity": "sha512-N4ntErOlKvcbTt01rr5wj3y55xnIdx1ymrfIr8C2WnM1Y9glFgWaGDEULJIazOX3XM9NRzhfJ6zZnQ1sBNWU+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
@@ -2099,7 +2098,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -2122,7 +2120,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -3050,7 +3047,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3174,7 +3170,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -3268,6 +3263,7 @@
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.46.0.tgz",
       "integrity": "sha512-C3Axuq1xd/9VqFZpW4YAzOx5O9q/LP46uIQy/iNDpHG3fmPa6TBtvfglMCs3RBiBxAIi0Go97r8+jvTt55XMyQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "comment-parser": "1.4.1",
         "esquery": "^1.6.0",
@@ -3737,6 +3733,7 @@
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -3759,13 +3756,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
+      "license": "Python-2.0",
+      "peer": true
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3776,6 +3775,7 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3788,6 +3788,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3800,6 +3801,7 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -3848,6 +3850,7 @@
       "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
@@ -3862,6 +3865,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3872,6 +3876,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3884,6 +3889,7 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -3897,7 +3903,430 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -4693,6 +5122,7 @@
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
       "integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       },
@@ -4943,7 +5373,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -5171,7 +5600,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
       "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -5317,7 +5745,8 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/node": {
       "version": "24.0.14",
@@ -5372,7 +5801,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5480,7 +5908,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
       "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
         "@typescript-eslint/scope-manager": "6.21.0",
@@ -5528,7 +5955,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -5719,7 +6145,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@vanilla-extract/babel-plugin-debug-ids": {
       "version": "1.2.2",
@@ -6091,7 +6518,6 @@
       "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-17.13.0.tgz",
       "integrity": "sha512-QnG5HmOd+XsweKOvrqbOugm9rINUjcsh1jo2SN4cbbTWZJ6nPmcfLS0YJdrKkgOQUnKDPQgBPVEyI8tp19OtBw==",
       "license": "GPL-2.0-or-later",
-      "peer": true,
       "dependencies": {
         "@babel/eslint-parser": "^7.16.0",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
@@ -6658,7 +7084,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6694,6 +7119,7 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -6728,7 +7154,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7087,6 +7512,7 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7102,6 +7528,7 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7350,7 +7777,8 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.1.0",
@@ -7625,7 +8053,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -7798,6 +8225,7 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
       "integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "camelcase": "^6.3.0",
         "map-obj": "^4.1.0",
@@ -7816,6 +8244,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8345,7 +8774,8 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
@@ -8635,6 +9065,7 @@
       "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
       "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12 || >=16"
       }
@@ -9083,6 +9514,7 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
       "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9095,6 +9527,7 @@
       "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
       "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "decamelize": "^1.1.0",
         "map-obj": "^1.0.0"
@@ -9111,6 +9544,7 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9120,6 +9554,7 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9173,7 +9608,8 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/deep-object-diff": {
       "version": "1.1.9",
@@ -9406,6 +9842,7 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -10092,7 +10529,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10169,7 +10605,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.14.0.tgz",
       "integrity": "sha512-P9s/qXSMTpRTerE2FQ0qJet2gKbcGyFTPAJipoKxmWqR6uuFqIqk8FuEfg5yBieOezVrEfAMZrEwJ6yEp+1MFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
@@ -10195,6 +10630,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.11.0.tgz",
       "integrity": "sha512-d12JHJDPNo7IFwTOAItCeJY1hcqoIxE0lHA8infQByLilQ9xkqrRa6laWCnsuCrf+8rUnvxXY1XuTbibRBNylA==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.46.0",
         "are-docs-informative": "^0.0.2",
@@ -10220,6 +10656,7 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -10232,6 +10669,7 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
@@ -10249,6 +10687,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -10261,7 +10700,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -10328,7 +10766,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.1.tgz",
       "integrity": "sha512-dobTkHT6XaEVOo8IO90Q4DOSxnm3Y151QxPJlM/vKC0bVy+d6cVWQZLlFiuZPP0wS6vZwSKeJgKkcS+KfMBlRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",
         "synckit": "^0.11.7"
@@ -10386,7 +10823,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -10419,7 +10855,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10537,13 +10972,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
+      "license": "Python-2.0",
+      "peer": true
     },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -10554,6 +10991,7 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -10570,6 +11008,7 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -10582,6 +11021,7 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -10594,6 +11034,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -10606,6 +11047,7 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -10623,6 +11065,7 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -10910,7 +11353,8 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.0.6",
@@ -10933,6 +11377,7 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.9.1"
       }
@@ -10996,6 +11441,7 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -11097,6 +11543,7 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
       "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
@@ -11110,7 +11557,8 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
@@ -11447,6 +11895,7 @@
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
       "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "global-prefix": "^3.0.0"
       },
@@ -11459,6 +11908,7 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
       "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ini": "^1.3.5",
         "kind-of": "^6.0.2",
@@ -11473,6 +11923,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -11535,7 +11986,8 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -11587,6 +12039,7 @@
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
       "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11860,6 +12313,7 @@
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
       "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -12195,6 +12649,7 @@
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
       "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12296,6 +12751,7 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12688,6 +13144,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13031,7 +13488,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -13812,7 +14268,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -13837,7 +14294,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json2php": {
       "version": "0.0.7",
@@ -13877,6 +14335,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -13886,6 +14345,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13947,6 +14407,7 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -14296,13 +14757,15 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -14559,6 +15022,7 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -14600,6 +15064,7 @@
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -14661,6 +15126,7 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
       "integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/minimist": "^1.2.2",
         "camelcase-keys": "^7.0.0",
@@ -14687,6 +15153,7 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
       "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^4.0.1",
         "is-core-module": "^2.5.0",
@@ -14702,6 +15169,7 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
       "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/normalize-package-data": "^2.4.0",
         "normalize-package-data": "^3.0.2",
@@ -14720,6 +15188,7 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
       "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-up": "^5.0.0",
         "read-pkg": "^6.0.0",
@@ -14737,6 +15206,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -14749,6 +15219,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14874,6 +15345,7 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -14933,6 +15405,7 @@
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
       "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "arrify": "^1.0.1",
         "is-plain-obj": "^1.1.0",
@@ -15716,6 +16189,7 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -15856,6 +16330,7 @@
       "resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-2.2.1.tgz",
       "integrity": "sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==",
       "license": "Apache-2.0 AND MIT",
+      "peer": true,
       "dependencies": {
         "es-module-lexer": "^1.5.3",
         "slashes": "^3.0.12"
@@ -16176,7 +16651,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -17414,6 +17888,7 @@
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0"
       },
@@ -17481,7 +17956,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -17511,6 +17985,7 @@
       "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-8.0.2.tgz",
       "integrity": "sha512-M9dkSrmU00t/jK7rF6BZSZauA5MAaBW4i5EnJXspMwt4iqTh/L9j6fgMnbElEOfyRyfLfVbIHj/R52zHzAPe1Q==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "postcss": "^8.4.20"
       }
@@ -17620,6 +18095,7 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -17629,7 +18105,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17850,6 +18325,7 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17919,7 +18395,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -17932,7 +18407,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17952,7 +18426,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18117,6 +18590,7 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
       "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "indent-string": "^5.0.0",
         "strip-indent": "^4.0.0"
@@ -18562,7 +19036,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.2.tgz",
       "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -18661,7 +19134,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19186,7 +19658,8 @@
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/slashes/-/slashes-3.0.12.tgz",
       "integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/slice-ansi": {
       "version": "5.0.0",
@@ -19657,6 +20130,7 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
       "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "min-indent": "^1.0.1"
       },
@@ -19683,7 +20157,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/stylehacks": {
       "version": "6.1.1",
@@ -19831,6 +20306,7 @@
       "resolved": "https://registry.npmjs.org/stylelint-declaration-strict-value/-/stylelint-declaration-strict-value-1.10.11.tgz",
       "integrity": "sha512-oVQvhZlFZAiDz9r2BPFZLtTGm1A2JVhdKObKAJoTjFfR4F/NpApC4bMBTxf4sZS76Na3njYKVOaAaKSZ4+FU+g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.12.0"
       },
@@ -19843,6 +20319,7 @@
       "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-6.0.4.tgz",
       "integrity": "sha512-0UuKo4+s1hgQ/uAxlYU4h0o0HS4NiQDud0NAUNI0aa8FJdmYHA5ZZTFHiV5FpmE3071e9pZx5j0QpVJW5zOCUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "postcss": "^8.4.32",
         "postcss-sorting": "^8.0.2"
@@ -19873,6 +20350,7 @@
       "integrity": "sha512-E3Mz68yqmZe5Zk5UraR5MA2DjxgfE2TCZerDPk+fcd9dwLjwRupAt0j+Q1fBJRE3vhh3PvToKDhvhfMHf1tfNg==",
       "deprecated": "This package has been deprecated in favor of @stylistic/stylelint-plugin",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-plain-object": "^5.0.0",
         "postcss": "^8.4.21",
@@ -19912,13 +20390,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
       "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-7.0.2.tgz",
       "integrity": "sha512-TfW7/1iI4Cy7Y8L6iqNdZQVvdXn0f8B4QcIXmkIbtTIe/Okm/nSlHb4IwGzRVOd3WfSieCgvf5cMzEfySAIl0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flat-cache": "^3.2.0"
       },
@@ -19931,6 +20411,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -19943,6 +20424,7 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -19990,6 +20472,7 @@
       "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
       "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
@@ -20022,7 +20505,8 @@
     "node_modules/svg-tags": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
-      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA=="
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "peer": true
     },
     "node_modules/svgo": {
       "version": "3.3.2",
@@ -20129,6 +20613,7 @@
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.3.tgz",
       "integrity": "sha512-JJoOEKTfL1urb1mDoEblhD9NhEbWmq9jHEMEnxoC4ujUaZ4itA8vKgwkFAyNClgxplLi9tsUKX+EduK0p/l7sg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pkgr/core": "^0.1.0",
         "tslib": "^2.6.2"
@@ -20145,6 +20630,7 @@
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
       "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -20161,6 +20647,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -20177,6 +20664,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -20185,13 +20673,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/table/node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -20405,7 +20895,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -20494,6 +20985,7 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
       "integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20590,6 +21082,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -20611,7 +21104,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -20711,7 +21203,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21069,7 +21560,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
       "integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -21176,7 +21666,6 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -21522,6 +22011,7 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21819,6 +22309,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -21839,6 +22330,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "format-js": "npm run format-js --workspaces --if-present",
     "lint-style": "npm run lint-style --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
-    "clean-dist": "npm run clean-dist --workspaces --if-present"
+    "clean-dist": "npm run clean-dist --workspaces --if-present",
+    "scaffold": "node bin/scaffold.mjs"
   },
   "author": {
     "name": "10up",
@@ -42,6 +43,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^15.2.0",
     "npm-run-all": "^4.1.5",
+    "@inquirer/prompts": "^7.0.0",
     "prettier": "3.3.3"
   }
 }


### PR DESCRIPTION
## Add interactive project scaffold CLI

Adds a Node.js CLI script (`bin/scaffold.mjs`) that automates the initial project setup when using this repo as a starter. Instead of manually finding and replacing placeholder strings across dozens of files, developers can run `npm run scaffold` and answer a few prompts.

### What it does

The script walks the user through:

1. **Hosting platform** - Standard WordPress or WordPress VIP (determines whether the plugin lives in `mu-plugins/` or `client-mu-plugins/`)
2. **Theme type** - Block Theme (recommended) or Classic Theme. The unused theme is deleted.
3. **Project name** - A human-readable name (e.g. "Acme Corp") from which all naming variants are derived automatically.
4. **Accept or customize** - The user can accept the auto-derived values or override each one individually (namespace, constants, text domain, slug, etc.).
5. **Project metadata** - Author name, email, URI, description, composer vendor, homepage, and repository URL. The repo URL is pre-populated from the git remote when available.

Once confirmed, the script:

- Deletes the unused theme directory
- Moves the plugin to `client-mu-plugins/` when VIP is selected
- Replaces all scaffold placeholder strings across PHP, JSON, YAML, XML, Markdown, and config files
- Handles both `TenupBlockTheme` and `TenUpBlockTheme` capitalization variants
- Handles the block theme's internal use of `tenup-theme` (style handles, text domains, pattern slugs) alongside `tenup-block-theme`
- Removes the deleted theme's constants from `phpstan/constants.php` and stale paths from `phpstan.neon`
- Renames directories (`10up-plugin` to `{slug}-plugin`, `10up-block-theme` to `{slug}-theme`)
- Renames the loader file and `.pot` translation files
- Fixes the plugin `package.json` `globalStylesDir`/`globalMixinsDir` paths
- Deletes `package-lock.json` and `composer.lock` files (must be regenerated after path changes)
- Cleans up after itself by removing the `scaffold` script and `@inquirer/prompts` dependency from `package.json`

### Files changed

- **`bin/scaffold.mjs`** (new) - The scaffold CLI script
- **`package.json`** - Added `scaffold` script and `@inquirer/prompts` dev dependency

### How to test

1. Clone the repo fresh
2. Run `npm install`
3. Run `npm run scaffold`
4. Walk through the prompts (try both block theme and classic theme, standard and VIP)
5. Verify all placeholder strings have been replaced: `grep -r "tenup\|TenUp\|Tenup\|TENUP\|10up-plugin\|10up-theme\|10up-block-theme" --include="*.php" --include="*.json" --include="*.css" --include="*.neon" --include="*.xml" --include="*.yml" .`
6. Verify `composer install` and `npm install` succeed after scaffolding
7. Verify `npm run build` completes without errors
