### PR TITLE
Feature: Add Plugin Scaffolding Command to Extend Initial Scaffold Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Run `npm run scaffold -- --help` to see all available options, including individ
 
 By default the script will ask whether you want to remove it after scaffolding is complete. You can also pass the `--self-destruct` flag to do this automatically. When enabled, the script removes the `bin/scaffold.mjs` file, the `scaffold` npm script, and the `@inquirer/prompts` dependency from `package.json`.
 
+### Adding New Plugins
+
+After your project is scaffolded, you can add additional plugins using the `scaffold:plugin` command. It downloads the reference 10up-plugin from GitHub and integrates it into your project:
+
+```bash
+npm run scaffold:plugin
+```
+
+The command auto-detects your project structure (standard or VIP), prompts for the plugin name and metadata, applies all replacements, and updates your project config files (`package.json`, `phpstan.neon`, `phpcs.xml`, CI workflows). See the [full documentation](docs/installation.md#adding-a-new-plugin) for all available options and flags.
+
 ### Manual Setup
 
 You can also set up the scaffold manually without the CLI:

--- a/bin/scaffold-helpers.mjs
+++ b/bin/scaffold-helpers.mjs
@@ -1,0 +1,124 @@
+/**
+ * Shared utilities for WordPress scaffold scripts
+ *
+ * @package TenUpScaffold
+ */
+
+import { execSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { join, extname } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const BINARY_EXTENSIONS = new Set([
+	'.png',
+	'.jpg',
+	'.jpeg',
+	'.gif',
+	'.webp',
+	'.ico',
+	'.svg',
+	'.woff',
+	'.woff2',
+	'.eot',
+	'.ttf',
+	'.otf',
+	'.zip',
+	'.gz',
+	'.tar',
+	'.bz2',
+	'.mp4',
+	'.mp3',
+	'.mov',
+	'.avi',
+	'.pdf',
+	'.doc',
+	'.docx',
+	'.lock',
+]);
+
+export const SKIP_DIRS = new Set(['node_modules', 'vendor', '.git', 'plugins']);
+
+// ---------------------------------------------------------------------------
+// Naming convention helpers
+// ---------------------------------------------------------------------------
+
+/** Convert "Acme Corp" to "acme-corp" */
+export function toKebab(name) {
+	return name
+		.replace(/([a-z])([A-Z])/g, '$1-$2')
+		.replace(/[\s_]+/g, '-')
+		.replace(/[^a-z0-9-]/gi, '')
+		.toLowerCase();
+}
+
+/** Convert "acme-corp" to "AcmeCorp" */
+export function toPascal(slug) {
+	return slug
+		.split('-')
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+		.join('');
+}
+
+/** Convert "acme-corp" to "ACME_CORP" */
+export function toConstant(slug) {
+	return slug.replace(/-/g, '_').toUpperCase();
+}
+
+/** Convert "acme-corp" to "acme_corp" */
+export function toSnake(slug) {
+	return slug.replace(/-/g, '_');
+}
+
+/** Convert "acme-corp" to "Acme Corp" */
+export function toTitle(slug) {
+	return slug
+		.split('-')
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+		.join(' ');
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+/** Try to read the git remote origin URL */
+export function getGitRemoteUrl(cwd) {
+	try {
+		const url = execSync('git remote get-url origin', { cwd, encoding: 'utf-8' }).trim();
+		// Normalize git@github.com:org/repo.git to https://github.com/org/repo
+		if (url.startsWith('git@')) {
+			return url.replace(/^git@([^:]+):/, 'https://$1/').replace(/\.git$/, '');
+		}
+		return url.replace(/\.git$/, '');
+	} catch {
+		return '';
+	}
+}
+
+/** Extract the org/user from a GitHub URL */
+export function getGitOrgFromUrl(url) {
+	const match = url.match(/github\.com\/([^/]+)/);
+	return match ? match[1].toLowerCase() : '';
+}
+
+// ---------------------------------------------------------------------------
+// File-walking helpers
+// ---------------------------------------------------------------------------
+
+export function walkFiles(dir, results = []) {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const fullPath = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (SKIP_DIRS.has(entry.name)) continue;
+			walkFiles(fullPath, results);
+		} else if (entry.isFile()) {
+			if (BINARY_EXTENSIONS.has(extname(entry.name).toLowerCase())) continue;
+			if (entry.name === 'package-lock.json') continue;
+			results.push(fullPath);
+		}
+	}
+	return results;
+}

--- a/bin/scaffold-plugin.mjs
+++ b/bin/scaffold-plugin.mjs
@@ -1,0 +1,560 @@
+#!/usr/bin/env node
+
+/**
+ * WordPress Plugin Scaffold CLI
+ *
+ * Downloads the reference 10up-plugin from GitHub and scaffolds it into an
+ * existing project with custom naming conventions.
+ *
+ * Run with: npm run scaffold:plugin
+ */
+
+import { input, confirm } from '@inquirer/prompts';
+import { createWriteStream, existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { pipeline } from 'node:stream/promises';
+import { createGunzip } from 'node:zlib';
+import { extract } from 'tar';
+import {
+	toKebab,
+	toPascal,
+	toConstant,
+	toSnake,
+	toTitle,
+	walkFiles,
+} from './scaffold-helpers.mjs';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ROOT = resolve(import.meta.dirname, '..');
+const TEMP_DIR = join(ROOT, '.scaffold-temp');
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+const CLI_OPTIONS = {
+	// Core
+	name: { type: 'string', short: 'n' },
+	'mu-dir': { type: 'string' },
+	ref: { type: 'string', default: 'trunk' },
+
+	// Plugin overrides
+	'plugin-slug': { type: 'string' },
+	'plugin-namespace': { type: 'string' },
+	'plugin-constant': { type: 'string' },
+	'plugin-text-domain': { type: 'string' },
+	'plugin-hook-prefix': { type: 'string' },
+	'plugin-human-name': { type: 'string' },
+	'plugin-npm-name': { type: 'string' },
+
+	// Metadata
+	'author-name': { type: 'string' },
+	'author-email': { type: 'string' },
+	'author-uri': { type: 'string' },
+	description: { type: 'string' },
+	'composer-vendor': { type: 'string' },
+
+	// Flags
+	yes: { type: 'boolean', short: 'y', default: false },
+	help: { type: 'boolean', default: false },
+};
+
+function printHelp() {
+	console.log(`
+  Usage: npm run scaffold:plugin -- [options]
+
+  Options:
+    -n, --name <name>               Plugin name (e.g. "Content Syndication")
+    --mu-dir <path>                 MU plugins directory (auto-detected if not provided)
+    --ref <branch|tag>              GitHub ref to download from (default: trunk)
+    -y, --yes                       Skip confirmation prompt
+
+  Plugin overrides:
+    --plugin-slug <slug>            Plugin directory and slug
+    --plugin-namespace <ns>         PHP namespace (e.g. ContentSyndicationPlugin)
+    --plugin-constant <prefix>      Constant prefix (e.g. CONTENT_SYNDICATION_PLUGIN)
+    --plugin-text-domain <domain>   Text domain
+    --plugin-hook-prefix <prefix>   Hook prefix (e.g. content_syndication_plugin)
+    --plugin-human-name <name>      Human-readable name
+    --plugin-npm-name <name>        npm package name
+
+  Metadata:
+    --author-name <name>            Author name
+    --author-email <email>          Author email
+    --author-uri <uri>              Author URI
+    --description <text>            Plugin description
+    --composer-vendor <vendor>      Composer vendor slug
+
+  Examples:
+    npm run scaffold:plugin
+    npm run scaffold:plugin -- -n "Content Syndication" -y
+    npm run scaffold:plugin -- \\
+      --name "Content Syndication" \\
+      --plugin-slug content-syndication \\
+      --composer-vendor acme \\
+      --yes
+`);
+}
+
+function parseCli() {
+	try {
+		const { values } = parseArgs({ options: CLI_OPTIONS, strict: true });
+		return values;
+	} catch (err) {
+		console.error(`\n  Error: ${err.message}\n`);
+		printHelp();
+		process.exit(1);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auto-detection helpers
+// ---------------------------------------------------------------------------
+
+function detectMuPluginsDir() {
+	const clientMu = join(ROOT, 'client-mu-plugins');
+	const standardMu = join(ROOT, 'mu-plugins');
+
+	if (existsSync(clientMu)) {
+		return clientMu;
+	}
+	if (existsSync(standardMu)) {
+		return standardMu;
+	}
+
+	throw new Error('Could not find mu-plugins or client-mu-plugins directory');
+}
+
+function detectComposerVendor() {
+	const composerPath = join(ROOT, 'composer.json');
+	if (!existsSync(composerPath)) {
+		return '';
+	}
+
+	try {
+		const composer = JSON.parse(readFileSync(composerPath, 'utf-8'));
+		const name = composer.name || '';
+		const vendor = name.split('/')[0];
+		return vendor || '';
+	} catch {
+		return '';
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GitHub download
+// ---------------------------------------------------------------------------
+
+async function downloadPluginFromGitHub(ref) {
+	console.log(`\n  Downloading 10up-plugin from GitHub (ref: ${ref})...\n`);
+
+	const tarballUrl = `https://api.github.com/repos/10up/wp-scaffold/tarball/${ref}`;
+
+	// Create temp directory
+	if (existsSync(TEMP_DIR)) {
+		rmSync(TEMP_DIR, { recursive: true, force: true });
+	}
+	mkdirSync(TEMP_DIR, { recursive: true });
+
+	// Download and extract
+	const response = await fetch(tarballUrl, {
+		headers: {
+			'User-Agent': 'wp-scaffold-plugin-cli',
+		},
+	});
+
+	if (!response.ok) {
+		throw new Error(`Failed to download from GitHub: ${response.statusText}`);
+	}
+
+	// Extract only the plugin files we need
+	await pipeline(
+		response.body,
+		createGunzip(),
+		extract({
+			cwd: TEMP_DIR,
+			strip: 2, // Strip "10up-wp-scaffold-<hash>/mu-plugins/"
+			filter: (path) => {
+				// Only extract mu-plugins/10up-plugin/ and mu-plugins/10up-plugin-loader.php
+				return path.includes('/mu-plugins/10up-plugin/') || path.endsWith('/mu-plugins/10up-plugin-loader.php');
+			},
+		}),
+	);
+
+	console.log('  Downloaded successfully\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+	const args = parseCli();
+
+	if (args.help) {
+		printHelp();
+		process.exit(0);
+	}
+
+	console.log('\n  WordPress Plugin Scaffold\n');
+
+	// -----------------------------------------------------------------------
+	// 1. Auto-detect settings
+	// -----------------------------------------------------------------------
+
+	const muDir = args['mu-dir'] || detectMuPluginsDir();
+	const detectedVendor = detectComposerVendor();
+
+	console.log(`  Detected mu-plugins directory: ${muDir.replace(ROOT + '/', '')}`);
+	if (detectedVendor) {
+		console.log(`  Detected composer vendor: ${detectedVendor}`);
+	}
+	console.log('');
+
+	// -----------------------------------------------------------------------
+	// 2. Prompts (or use CLI args)
+	// -----------------------------------------------------------------------
+
+	const pluginName = args.name
+		? args.name
+		: await input({
+				message: 'Plugin name (human-readable, e.g. "Content Syndication"):',
+				validate: (v) => (v.trim().length > 0 ? true : 'Plugin name is required.'),
+			});
+
+	const slug = toKebab(pluginName.trim());
+
+	// Derive defaults
+	const defaults = {
+		pluginSlug: args['plugin-slug'] || `${slug}-plugin`,
+		pluginNamespace: args['plugin-namespace'] || `${toPascal(slug)}Plugin`,
+		pluginConstant: args['plugin-constant'] || `${toConstant(slug)}_PLUGIN`,
+		pluginTextDomain: args['plugin-text-domain'] || `${slug}-plugin`,
+		pluginHookPrefix: args['plugin-hook-prefix'] || `${toSnake(slug)}_plugin`,
+		pluginHumanName: args['plugin-human-name'] || `${toTitle(slug)} Plugin`,
+		pluginNpmName: args['plugin-npm-name'] || `${slug}-plugin`,
+		authorName: args['author-name'] || '',
+		authorEmail: args['author-email'] || '',
+		authorUri: args['author-uri'] || '',
+		description: args.description || '',
+		composerVendor: args['composer-vendor'] || detectedVendor || slug,
+	};
+
+	const isNonInteractive = !!args.name;
+
+	// Prompt for metadata if interactive
+	if (!isNonInteractive) {
+		console.log('\n  Derived values:\n');
+		console.log(`  Plugin directory:     ${defaults.pluginSlug}`);
+		console.log(`  Plugin namespace:     ${defaults.pluginNamespace}`);
+		console.log(`  Plugin constants:     ${defaults.pluginConstant}_*`);
+		console.log(`  Plugin text domain:   ${defaults.pluginTextDomain}`);
+		console.log(`  Plugin human name:    ${defaults.pluginHumanName}`);
+		console.log('');
+
+		defaults.authorName = await input({
+			message: 'Author name:',
+			default: defaults.authorName,
+		});
+		defaults.authorEmail = await input({
+			message: 'Author email:',
+			default: defaults.authorEmail,
+		});
+		defaults.authorUri = await input({
+			message: 'Author URI:',
+			default: defaults.authorUri,
+		});
+		defaults.description = await input({
+			message: 'Plugin description:',
+			default: defaults.description,
+		});
+		defaults.composerVendor = await input({
+			message: 'Composer vendor slug:',
+			default: defaults.composerVendor,
+		});
+	}
+
+	const values = defaults;
+
+	// -----------------------------------------------------------------------
+	// 3. Confirm
+	// -----------------------------------------------------------------------
+
+	console.log('\n  Summary:\n');
+	console.log(`  Plugin:               ${values.pluginSlug} (${values.pluginNamespace})`);
+	if (values.authorName) console.log(`  Author:               ${values.authorName}`);
+	if (values.description) console.log(`  Description:          ${values.description}`);
+	console.log('');
+
+	if (!args.yes) {
+		const ok = await confirm({ message: 'Download and scaffold this plugin?', default: true });
+		if (!ok) {
+			console.log('\n  Aborted. No changes were made.\n');
+			process.exit(0);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// 4. Download from GitHub
+	// -----------------------------------------------------------------------
+
+	await downloadPluginFromGitHub(args.ref);
+
+	// -----------------------------------------------------------------------
+	// 5. String replacements
+	// -----------------------------------------------------------------------
+
+	console.log('  Applying string replacements...\n');
+
+	const replacements = [];
+
+	// Plugin replacements
+	replacements.push(
+		['TenUpPlugin', values.pluginNamespace],
+		['TENUP_PLUGIN', values.pluginConstant],
+		['tenup-plugin', values.pluginSlug],
+		['tenup_plugin', values.pluginHookPrefix],
+		['10up-plugin', values.pluginSlug],
+		['10up Plugin Scaffold', values.pluginHumanName],
+	);
+
+	// Composer package name
+	replacements.push(['10up/wp-plugin', `${values.composerVendor}/${values.pluginSlug}`]);
+
+	// Author / metadata
+	if (values.authorEmail) {
+		replacements.push(['info@10up.com', values.authorEmail]);
+	}
+	if (values.authorName) {
+		replacements.push(['10up', values.authorName]);
+	}
+	if (values.authorUri) {
+		replacements.push(['https://10up.com', values.authorUri]);
+	}
+	if (values.description) {
+		replacements.push(['A brief description of the plugin.', values.description]);
+	}
+
+	// Sort by length descending to avoid partial matches
+	replacements.sort((a, b) => b[0].length - a[0].length);
+
+	// Walk all files in the temp directory
+	const files = walkFiles(TEMP_DIR);
+	let filesChanged = 0;
+
+	for (const filePath of files) {
+		let content;
+		try {
+			content = readFileSync(filePath, 'utf-8');
+		} catch {
+			continue;
+		}
+
+		let changed = false;
+		for (const [oldStr, newStr] of replacements) {
+			if (content.includes(oldStr)) {
+				content = content.replaceAll(oldStr, newStr);
+				changed = true;
+			}
+		}
+
+		if (changed) {
+			writeFileSync(filePath, content);
+			filesChanged++;
+		}
+	}
+
+	console.log(`  Updated ${filesChanged} file(s)\n`);
+
+	// -----------------------------------------------------------------------
+	// 6. Move files to the correct location
+	// -----------------------------------------------------------------------
+
+	console.log('  Moving plugin files into place...\n');
+
+	const tempPluginDir = join(TEMP_DIR, '10up-plugin');
+	const tempLoaderFile = join(TEMP_DIR, '10up-plugin-loader.php');
+
+	const finalPluginDir = join(muDir, values.pluginSlug);
+	const finalLoaderFile = join(muDir, `${values.pluginSlug}-loader.php`);
+
+	// Move plugin directory
+	if (existsSync(tempPluginDir)) {
+		if (existsSync(finalPluginDir)) {
+			throw new Error(`Plugin directory already exists: ${finalPluginDir}`);
+		}
+		mkdirSync(finalPluginDir, { recursive: true });
+		// Copy contents
+		const { execSync } = await import('node:child_process');
+		execSync(`cp -R "${tempPluginDir}/." "${finalPluginDir}"`);
+		console.log(`  Created ${muDir.replace(ROOT + '/', '')}/${values.pluginSlug}/`);
+	}
+
+	// Move loader file
+	if (existsSync(tempLoaderFile)) {
+		if (existsSync(finalLoaderFile)) {
+			throw new Error(`Loader file already exists: ${finalLoaderFile}`);
+		}
+		let loaderContent = readFileSync(tempLoaderFile, 'utf-8');
+		// Fix the require path
+		loaderContent = loaderContent.replaceAll('10up-plugin', values.pluginSlug);
+		writeFileSync(finalLoaderFile, loaderContent);
+		console.log(`  Created ${muDir.replace(ROOT + '/', '')}/${values.pluginSlug}-loader.php`);
+	}
+
+	// Clean up temp directory
+	rmSync(TEMP_DIR, { recursive: true, force: true });
+
+	// -----------------------------------------------------------------------
+	// 7. Integrate with project config files
+	// -----------------------------------------------------------------------
+
+	console.log('\n  Integrating with project config...\n');
+
+	// Update package.json
+	const pkgPath = join(ROOT, 'package.json');
+	if (existsSync(pkgPath)) {
+		const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+
+		// Add to workspaces
+		const workspacePath = `${muDir.replace(ROOT + '/', '')}/${values.pluginSlug}`;
+		if (!pkg.workspaces.includes(workspacePath)) {
+			pkg.workspaces.push(workspacePath);
+		}
+
+		// Add watch script
+		const watchScriptName = `watch:${values.pluginNpmName}`;
+		if (!pkg.scripts[watchScriptName]) {
+			pkg.scripts[watchScriptName] = `npm run watch -w=${values.pluginNpmName}`;
+		}
+
+		// Update main watch script to include new plugin
+		if (pkg.scripts.watch && !pkg.scripts.watch.includes(watchScriptName)) {
+			pkg.scripts.watch = `${pkg.scripts.watch.replace('run-p', 'run-p')} ${watchScriptName}`;
+		}
+
+		writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+		console.log('  Updated package.json (workspaces, watch scripts)');
+	}
+
+	// Update phpstan.neon
+	const phpstanPath = join(ROOT, 'phpstan.neon');
+	if (existsSync(phpstanPath)) {
+		let phpstanContent = readFileSync(phpstanPath, 'utf-8');
+		const pluginPath = `${muDir.replace(ROOT + '/', '')}/${values.pluginSlug}`;
+		const loaderPath = `${muDir.replace(ROOT + '/', '')}/${values.pluginSlug}-loader.php`;
+
+		if (!phpstanContent.includes(pluginPath)) {
+			// Add before the closing of the paths array
+			phpstanContent = phpstanContent.replace(
+				/(\s+paths:\s*\n(?:\s+-\s+.+\n)+)/,
+				`$1\t\t- ${pluginPath}\n\t\t- ${loaderPath}\n`,
+			);
+			writeFileSync(phpstanPath, phpstanContent);
+			console.log('  Updated phpstan.neon (added plugin paths)');
+		}
+	}
+
+	// Update phpstan/constants.php
+	const constantsPath = join(ROOT, 'phpstan', 'constants.php');
+	if (existsSync(constantsPath)) {
+		let constantsContent = readFileSync(constantsPath, 'utf-8');
+
+		const newConstants = `
+// ${values.pluginHumanName} constants
+define( '${values.pluginConstant}_VERSION', '0.1.0' );
+define( '${values.pluginConstant}_URL', '' );
+define( '${values.pluginConstant}_PATH', '' );
+define( '${values.pluginConstant}_INC', ${values.pluginConstant}_PATH . 'includes/' );
+`;
+
+		if (!constantsContent.includes(values.pluginConstant)) {
+			// Add before the closing PHP tag or at the end
+			constantsContent = constantsContent.trimEnd() + '\n' + newConstants;
+			writeFileSync(constantsPath, constantsContent);
+			console.log('  Updated phpstan/constants.php (added plugin constants)');
+		}
+	}
+
+	// Update phpcs.xml
+	const phpcsPath = join(ROOT, 'phpcs.xml');
+	if (existsSync(phpcsPath)) {
+		let phpcsContent = readFileSync(phpcsPath, 'utf-8');
+		const loaderPath = `./${muDir.replace(ROOT + '/', '')}/${values.pluginSlug}-loader.php`;
+
+		if (!phpcsContent.includes(loaderPath)) {
+			// Add exclusion rule for the loader file
+			const exclusionRule = `
+	<!-- Ignore filecomment for the plugin loader -->
+	<rule ref="Squiz.Commenting.FileComment.Missing">
+		<exclude-pattern>${loaderPath}</exclude-pattern>
+	</rule>
+`;
+
+			// Insert before the closing </ruleset> tag
+			phpcsContent = phpcsContent.replace('</ruleset>', `${exclusionRule}\n</ruleset>`);
+			writeFileSync(phpcsPath, phpcsContent);
+			console.log('  Updated phpcs.xml (added loader exclusion)');
+		}
+	}
+
+	// Update .github/workflows/php.yml
+	const phpWorkflowPath = join(ROOT, '.github', 'workflows', 'php.yml');
+	if (existsSync(phpWorkflowPath)) {
+		let workflowContent = readFileSync(phpWorkflowPath, 'utf-8');
+		const pluginPath = `${muDir.replace(ROOT + '/', '')}/${values.pluginSlug}`;
+
+		if (!workflowContent.includes(pluginPath)) {
+			// Add composer validate step
+			const validateStep = `
+      - name: Validate ${values.pluginHumanName} composer.json and composer.lock
+        run: composer validate --strict --working-dir=${pluginPath}
+`;
+
+			// Add after the last validate step
+			workflowContent = workflowContent.replace(
+				/(- name: Validate .+ composer\.json and composer\.lock\s+run: composer validate[^\n]+\n)/g,
+				(match) => match + validateStep,
+			);
+
+			// Add composer install step
+			const installStep = `
+      - name: Install ${values.pluginHumanName} dependencies
+        run: composer install --prefer-dist --no-progress --working-dir=${pluginPath}
+`;
+
+			// Add after the last install step
+			workflowContent = workflowContent.replace(
+				/(- name: Install .+ dependencies\s+run: composer install[^\n]+\n)/g,
+				(match) => match + installStep,
+			);
+
+			writeFileSync(phpWorkflowPath, workflowContent);
+			console.log('  Updated .github/workflows/php.yml (added CI steps)');
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Done!
+	// -----------------------------------------------------------------------
+
+	console.log('\n  Done! Your plugin has been scaffolded.\n');
+	console.log('  Next steps:\n');
+	console.log('    1. Run npm install');
+	console.log(`    2. Run composer install in ${pluginPath}`);
+	console.log('    3. Run npm run build');
+	console.log('    4. Start developing!\n');
+}
+
+main().catch((err) => {
+	if (err.name === 'ExitPromptError') {
+		console.log('\n  Aborted.\n');
+		process.exit(0);
+	}
+	console.error('\n  Error:', err.message, '\n');
+	process.exit(1);
+});

--- a/bin/scaffold.mjs
+++ b/bin/scaffold.mjs
@@ -10,131 +10,32 @@
  */
 
 import { select, input, confirm } from '@inquirer/prompts';
-import { execSync } from 'node:child_process';
 import {
 	existsSync,
-	readdirSync,
 	readFileSync,
 	writeFileSync,
 	renameSync,
 	rmSync,
 	mkdirSync,
 } from 'node:fs';
-import { join, resolve, extname } from 'node:path';
+import { join, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
+import {
+	toKebab,
+	toPascal,
+	toConstant,
+	toSnake,
+	toTitle,
+	getGitRemoteUrl,
+	getGitOrgFromUrl,
+	walkFiles,
+} from './scaffold-helpers.mjs';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 const ROOT = resolve(import.meta.dirname, '..');
-
-const BINARY_EXTENSIONS = new Set([
-	'.png',
-	'.jpg',
-	'.jpeg',
-	'.gif',
-	'.webp',
-	'.ico',
-	'.svg',
-	'.woff',
-	'.woff2',
-	'.eot',
-	'.ttf',
-	'.otf',
-	'.zip',
-	'.gz',
-	'.tar',
-	'.bz2',
-	'.mp4',
-	'.mp3',
-	'.mov',
-	'.avi',
-	'.pdf',
-	'.doc',
-	'.docx',
-	'.lock',
-]);
-
-const SKIP_DIRS = new Set(['node_modules', 'vendor', '.git', 'plugins']);
-
-// ---------------------------------------------------------------------------
-// Utility helpers
-// ---------------------------------------------------------------------------
-
-/** Convert "Acme Corp" to "acme-corp" */
-function toKebab(name) {
-	return name
-		.replace(/([a-z])([A-Z])/g, '$1-$2')
-		.replace(/[\s_]+/g, '-')
-		.replace(/[^a-z0-9-]/gi, '')
-		.toLowerCase();
-}
-
-/** Convert "acme-corp" to "AcmeCorp" */
-function toPascal(slug) {
-	return slug
-		.split('-')
-		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-		.join('');
-}
-
-/** Convert "acme-corp" to "ACME_CORP" */
-function toConstant(slug) {
-	return slug.replace(/-/g, '_').toUpperCase();
-}
-
-/** Convert "acme-corp" to "acme_corp" */
-function toSnake(slug) {
-	return slug.replace(/-/g, '_');
-}
-
-/** Convert "acme-corp" to "Acme Corp" */
-function toTitle(slug) {
-	return slug
-		.split('-')
-		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-		.join(' ');
-}
-
-/** Try to read the git remote origin URL */
-function getGitRemoteUrl() {
-	try {
-		const url = execSync('git remote get-url origin', { cwd: ROOT, encoding: 'utf-8' }).trim();
-		// Normalize git@github.com:org/repo.git to https://github.com/org/repo
-		if (url.startsWith('git@')) {
-			return url.replace(/^git@([^:]+):/, 'https://$1/').replace(/\.git$/, '');
-		}
-		return url.replace(/\.git$/, '');
-	} catch {
-		return '';
-	}
-}
-
-/** Extract the org/user from a GitHub URL */
-function getGitOrgFromUrl(url) {
-	const match = url.match(/github\.com\/([^/]+)/);
-	return match ? match[1].toLowerCase() : '';
-}
-
-// ---------------------------------------------------------------------------
-// File-walking helpers
-// ---------------------------------------------------------------------------
-
-function walkFiles(dir, results = []) {
-	for (const entry of readdirSync(dir, { withFileTypes: true })) {
-		const fullPath = join(dir, entry.name);
-		if (entry.isDirectory()) {
-			if (SKIP_DIRS.has(entry.name)) continue;
-			walkFiles(fullPath, results);
-		} else if (entry.isFile()) {
-			if (BINARY_EXTENSIONS.has(extname(entry.name).toLowerCase())) continue;
-			if (entry.name === 'package-lock.json') continue;
-			results.push(fullPath);
-		}
-	}
-	return results;
-}
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing
@@ -283,7 +184,7 @@ async function main() {
 	const slug = toKebab(projectName.trim());
 
 	// Auto-detect git remote
-	const gitRemoteUrl = getGitRemoteUrl();
+	const gitRemoteUrl = getGitRemoteUrl(ROOT);
 	const gitOrg = getGitOrgFromUrl(gitRemoteUrl);
 
 	// -----------------------------------------------------------------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Welcome to the documentation for the WP Scaffold! This is your starting point fo
 - [Getting Started](#getting-started)
 - [Installation](./installation.md)
 - [Scaffold CLI](./installation.md#running-the-scaffold-cli)
+- [Adding New Plugins](./installation.md#adding-a-new-plugin)
 - [Architecture Overview](./backend-development/architecture-overview.md)
 - [Contributing Guidelines](./contributing-community/contributing-guidelines.md)
 - [Troubleshooting Guide](./troubleshooting-faq/troubleshooting-guide.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -128,6 +128,78 @@ npm run build
 
 You will also need to run `composer install` inside the mu-plugin and theme directories where `composer.json` files exist.
 
+## Adding a New Plugin
+
+After your project is scaffolded and underway, you may need to add additional plugins. The `scaffold:plugin` command downloads the reference 10up-plugin from GitHub and integrates it into your existing project.
+
+### Interactive mode
+
+```bash
+npm run scaffold:plugin
+```
+
+The CLI walks you through:
+
+1. **Plugin name** - A human-readable name like "Content Syndication". All other naming conventions are derived automatically.
+2. **Metadata** - Author name, email, URI, description, and Composer vendor slug. The vendor slug is auto-detected from your existing `composer.json`.
+
+The script automatically detects whether your project uses `mu-plugins/` or `client-mu-plugins/` (for VIP projects).
+
+### Non-interactive mode
+
+```bash
+npm run scaffold:plugin -- \
+  --name "Content Syndication" \
+  --composer-vendor acme \
+  --yes
+```
+
+### All available flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--name` | `-n` | Plugin name (e.g. "Content Syndication") |
+| `--mu-dir` | | MU plugins directory (auto-detected if not provided) |
+| `--ref` | | GitHub ref to download from (default: trunk) |
+| `--yes` | `-y` | Skip confirmation prompt |
+| `--plugin-slug` | | Plugin directory and slug |
+| `--plugin-namespace` | | PHP namespace (e.g. ContentSyndicationPlugin) |
+| `--plugin-constant` | | Constant prefix (e.g. CONTENT_SYNDICATION_PLUGIN) |
+| `--plugin-text-domain` | | Text domain |
+| `--plugin-hook-prefix` | | Hook prefix (e.g. content_syndication_plugin) |
+| `--plugin-human-name` | | Human-readable name |
+| `--plugin-npm-name` | | npm package name |
+| `--author-name` | | Author name |
+| `--author-email` | | Author email |
+| `--author-uri` | | Author URI |
+| `--description` | | Plugin description |
+| `--composer-vendor` | | Composer vendor slug |
+
+### What it does
+
+When you run the command, it:
+
+1. Auto-detects your project's mu-plugins directory (`mu-plugins/` or `client-mu-plugins/`)
+2. Downloads the reference plugin from the 10up/wp-scaffold GitHub repository
+3. Applies all string replacements (namespaces, constants, slugs, text domains, metadata)
+4. Places the plugin and loader file in the correct directory
+5. Updates project config files:
+   - `package.json` - adds workspace, adds watch script
+   - `phpstan.neon` - adds plugin paths
+   - `phpstan/constants.php` - adds plugin constants
+   - `phpcs.xml` - adds loader file exclusion
+   - `.github/workflows/php.yml` - adds CI steps
+
+### After adding a plugin
+
+Run the following to integrate the new plugin:
+
+```bash
+npm install
+composer install --working-dir=mu-plugins/your-plugin-slug
+npm run build
+```
+
 ## Database Setup
 - Local WP will create a database for your site automatically.
 - If you have a database dump (e.g., `local.sql`), import it using Local WP's database tools or via the command line.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint-style": "npm run lint-style --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "clean-dist": "npm run clean-dist --workspaces --if-present",
-    "scaffold": "node bin/scaffold.mjs"
+    "scaffold": "node bin/scaffold.mjs",
+    "scaffold:plugin": "node bin/scaffold-plugin.mjs"
   },
   "author": {
     "name": "10up",
@@ -44,6 +45,7 @@
     "lint-staged": "^15.2.0",
     "npm-run-all": "^4.1.5",
     "@inquirer/prompts": "^7.0.0",
-    "prettier": "3.3.3"
+    "prettier": "3.3.3",
+    "tar": "^7.4.3"
   }
 }


### PR DESCRIPTION
## Summary

Builds on #313 to add a new `scaffold:plugin` command that enables scaffolding additional plugins into an already-initialized project. This demonstrates the extensibility of the scaffold infrastructure by downloading the reference plugin from GitHub and integrating it seamlessly into the existing codebase.

## What Changed

### New Plugin Scaffold Command

- **`bin/scaffold-plugin.mjs`** - New CLI tool that downloads the 10up-plugin reference from GitHub and scaffolds it into an existing project
- **`bin/scaffold-helpers.mjs`** - Extracted shared utilities (naming helpers, file walking, constants) from the original scaffold for reuse
- **`bin/scaffold.mjs`** - Updated to import from the shared helpers module

### Features

- Auto-detects hosting platform (`mu-plugins/` vs `client-mu-plugins/` for VIP)
- Auto-detects Composer vendor slug from existing `composer.json`
- Downloads reference plugin from GitHub (no local template needed)
- Supports interactive and non-interactive modes with full CLI flag support
- Applies all string replacements (namespaces, constants, slugs, metadata)
- Automatically integrates with project config:
  - `package.json` - workspaces and watch scripts
  - `phpstan.neon` - plugin paths
  - `phpstan/constants.php` - plugin constants
  - `phpcs.xml` - loader file exclusions
  - `.github/workflows/php.yml` - CI validation and install steps

### Documentation

- Added comprehensive "Adding a New Plugin" section to `docs/installation.md`
- Updated `README.md` with overview and link to full docs
- Added table of contents entry in `docs/README.md`

## Usage

### Interactive
```bash
npm run scaffold:plugin
```

### Non-interactive
```bash
npm run scaffold:plugin -- \
  --name "Content Syndication" \
  --composer-vendor acme \
  --yes
```

## Why This Matters

This demonstrates how the scaffold infrastructure from #313 can be extended to handle incremental scaffolding tasks. After the initial project setup, teams often need to add additional plugins. Instead of manually copying and renaming files, this command:

1. Pulls the latest reference plugin from the wp-scaffold repo
2. Applies the same proven replacement logic
3. Integrates seamlessly with all project config files

This pattern can be extended in the future to support scaffolding additional themes, blocks, or other components.

## Dependencies

- Added `tar` (v7.4.3) for extracting GitHub tarballs

## Test Plan

1. Run the initial scaffold: `npm run scaffold`
2. Choose a project name and complete the setup
3. Run `npm run scaffold:plugin` to add a new plugin
4. Verify the plugin directory is created with correct naming
5. Verify `package.json`, `phpstan.neon`, `phpcs.xml`, and CI workflows are updated
6. Run `npm install` and `composer install` in the new plugin
7. Run `npm run build` to verify the plugin builds correctly
8. Test non-interactive mode with various flags
