### PR TITLE
Add missing readdirSync import

### DIFF
--- a/bin/scaffold.mjs
+++ b/bin/scaffold.mjs
@@ -14,6 +14,7 @@ import {
 	existsSync,
 	readFileSync,
 	writeFileSync,
+	readdirSync,
 	renameSync,
 	rmSync,
 	mkdirSync,


### PR DESCRIPTION
### Description of the Change
`npm run scaffold` was erroring because of missing `readdirSync` in `bin/scaffold.mjs`.
Add the import back.

### How to test the Change
Run `npm run scaffold`, the command should now be able to complete properly.

### Changelog Entry
Fixed - Bug fix - scaffold.mjs missing import

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, ...

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
