### PR TITLE
fix: husky pre-commit running lint-staged in wrong directory

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,6 +2,9 @@ PARENT_DIR="$(git rev-parse --show-toplevel)"
 SCAFFOLD_PATH=$(grep hooksPath "${PARENT_DIR}"/.git/config | awk '{print $3}')
 
 if [ ! -z "${SCAFFOLD_PATH}" ]; then
+  # Husky v9+ sets hooksPath to `<scaffold>/.husky/_`; strip the trailing `/_`
+  # so we cd to the scaffold root (where .lintstagedrc.json lives) and not into .husky.
+  SCAFFOLD_PATH="${SCAFFOLD_PATH%/_}"
   cd "${PARENT_DIR}/${SCAFFOLD_PATH}/.."
 fi
 npx lint-staged


### PR DESCRIPTION
## Summary

- Husky v9+ sets `core.hooksPath` to `<scaffold>/.husky/_` (with the trailing `/_`), so the existing `${PARENT_DIR}/${SCAFFOLD_PATH}/..` math in `.husky/pre-commit` landed inside `.husky/` instead of the scaffold root.
- `npx lint-staged` then ran from `.husky/`, couldn't find `.lintstagedrc.json`, and silently passed every commit (`→ No staged files found.`).
- Strip a trailing `/_` from `SCAFFOLD_PATH` before cd-ing — works for both husky v9+ (`./.husky/_`) and older husky (`./.husky`), and doesn't depend on the scaffold being named `wp-content`.

Fixes #307

## Test plan

- [x] With the fix, committing a JS file containing lint errors (per the repro in #307) now triggers `10up-toolkit lint-js`, reports the errors, and blocks the commit (exit 1).
- [x] On `trunk` without the fix, the same staged file produces `→ No staged files found.` and the commit goes through.
- [ ] Verify on a VIP/scaffold-overlay setup where the scaffold lives in a subdirectory of the git root (path math should still resolve to the scaffold root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)