### PR TITLE
fix: output dir="ltr" attribute for LTR languages

### DIFF
--- a/themes/10up-block-theme/src/ThemeCore.php
+++ b/themes/10up-block-theme/src/ThemeCore.php
@@ -29,6 +29,8 @@ class ThemeCore {
 		add_action( 'wp_head', [ $this, 'js_detection' ], 0 );
 		add_action( 'wp_head', [ $this, 'scrollbar_detection' ], 0 );
 
+		add_filter( 'language_attributes', [ $this, 'add_ltr_language_attribute' ] );
+
 		do_action( 'tenup_block_theme_loaded' );
 	}
 
@@ -110,6 +112,24 @@ class ThemeCore {
 	 */
 	public function scrollbar_detection() {
 		echo '<script>window.addEventListener("DOMContentLoaded",()=>{const t=()=>window.innerWidth-document.body.clientWidth;const e=()=>{document.documentElement.style.setProperty("--wp--custom--scrollbar-width",`${t()}px`)};e();});</script>' . "\n";
+	}
+
+	/**
+	 * Adds an explicit `dir="ltr"` attribute to the `<html>` tag for LTR languages.
+	 *
+	 * WordPress core only outputs the `dir` attribute when the site is RTL, but
+	 * `postcss-logical` scopes generated rules to both `html[dir="ltr"]` and
+	 * `html[dir="rtl"]`. Without this filter, LTR rules never match.
+	 *
+	 * @param string $output A space-separated string of attributes.
+	 * @return string
+	 */
+	public function add_ltr_language_attribute( $output ) {
+		if ( ! is_rtl() ) {
+			$output .= ' dir="ltr"';
+		}
+
+		return $output;
 	}
 
 	/**

--- a/themes/10up-block-theme/src/ThemeCore.php
+++ b/themes/10up-block-theme/src/ThemeCore.php
@@ -125,7 +125,7 @@ class ThemeCore {
 	 * @return string
 	 */
 	public function add_ltr_language_attribute( $output ) {
-		if ( ! is_rtl() ) {
+		if ( ! is_rtl() && ! preg_match( '/\bdir\s*=/', $output ) ) {
 			$output .= ' dir="ltr"';
 		}
 

--- a/themes/10up-theme/src/ThemeCore.php
+++ b/themes/10up-theme/src/ThemeCore.php
@@ -29,6 +29,8 @@ class ThemeCore {
 		add_action( 'wp_head', [ $this, 'js_detection' ], 0 );
 		add_action( 'wp_head', [ $this, 'scrollbar_detection' ], 0 );
 
+		add_filter( 'language_attributes', [ $this, 'add_ltr_language_attribute' ] );
+
 		do_action( 'tenup_theme_loaded' );
 	}
 
@@ -135,6 +137,24 @@ class ThemeCore {
 	 */
 	public function scrollbar_detection() {
 		echo '<script>window.addEventListener("DOMContentLoaded",()=>{const t=()=>window.innerWidth-document.body.clientWidth;const e=()=>{document.documentElement.style.setProperty("--wp--custom--scrollbar-width",`${t()}px`)};e();});</script>' . "\n";
+	}
+
+	/**
+	 * Adds an explicit `dir="ltr"` attribute to the `<html>` tag for LTR languages.
+	 *
+	 * WordPress core only outputs the `dir` attribute when the site is RTL, but
+	 * `postcss-logical` scopes generated rules to both `html[dir="ltr"]` and
+	 * `html[dir="rtl"]`. Without this filter, LTR rules never match.
+	 *
+	 * @param string $output A space-separated string of attributes.
+	 * @return string
+	 */
+	public function add_ltr_language_attribute( $output ) {
+		if ( ! is_rtl() ) {
+			$output .= ' dir="ltr"';
+		}
+
+		return $output;
 	}
 
 	/**

--- a/themes/10up-theme/src/ThemeCore.php
+++ b/themes/10up-theme/src/ThemeCore.php
@@ -150,7 +150,7 @@ class ThemeCore {
 	 * @return string
 	 */
 	public function add_ltr_language_attribute( $output ) {
-		if ( ! is_rtl() ) {
+		if ( ! is_rtl() && ! preg_match( '/\bdir\s*=/i', $output ) ) {
 			$output .= ' dir="ltr"';
 		}
 


### PR DESCRIPTION
## Summary
- Adds a `language_attributes` filter to both `10up-theme` and `10up-block-theme` that appends `dir="ltr"` when `is_rtl()` is false.
- WordPress core only emits a `dir` attribute on `<html>` for RTL sites, but `postcss-logical` scopes generated rules to both `html[dir="ltr"]` and `html[dir="rtl"]`. Without this, LTR-scoped rules never match.

Fixes #174

## Test plan
- [ ] Load a page on a default LTR site and confirm `<html>` includes `dir="ltr"`.
- [ ] Switch the site to an RTL locale (e.g. `ar`) and confirm `<html>` includes `dir="rtl"` (and not both).
- [ ] Verify CSS rules generated by `postcss-logical` under `html[dir="ltr"]` now apply on LTR sites.
- [ ] Repeat the above for both `10up-theme` and `10up-block-theme`.