### PR TITLE
Remove duplicate entry of readdirSync from scaffold.mjs

### DIFF
--- a/bin/scaffold.mjs
+++ b/bin/scaffold.mjs
@@ -16,7 +16,6 @@ import {
 	readFileSync,
 	readdirSync,
 	writeFileSync,
-	readdirSync,
 	renameSync,
 	rmSync,
 	mkdirSync,


### PR DESCRIPTION

Remove duplicate entry of readdirSync from scaffold.mjs
readdirSync is imported twice (lines 17 and 19) in `bin/scaffold.mjs`
This was causing error when running `npm run scaffold`  command.

Fixes. - https://github.com/10up/wp-scaffold/issues/330

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #330

### How to test the Change
Download the 10up/wp-scaffold to any existing or a new project.
Run `npm install`
Run `npm run scaffold`
`npm run scaffold` should pass without any error

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
> Developer - Non-functional update

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ajmaurya99 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
